### PR TITLE
fix: fetch WebSocket URL from /json/version for Chrome 115+ compatibility

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -97,7 +97,19 @@ function checkPort(port) {
   });
 }
 
-function getWebSocketUrl(chromePort) {
+async function getWebSocketUrl(chromePort) {
+  // Chrome 115+ removed the generic /devtools/browser endpoint.
+  // The correct WebSocket URL (with a unique browser UUID) must be
+  // fetched from /json/version before each connection attempt.
+  try {
+    const resp = await fetch(`http://127.0.0.1:${chromePort}/json/version`);
+    const info = await resp.json();
+    if (info.webSocketDebuggerUrl) {
+      // Normalize to 127.0.0.1 in case Chrome returns "localhost"
+      return info.webSocketDebuggerUrl.replace('ws://localhost:', 'ws://127.0.0.1:');
+    }
+  } catch { /* fall through to legacy path */ }
+  // Fallback for older Chrome / Chromium versions
   return `ws://127.0.0.1:${chromePort}/devtools/browser`;
 }
 


### PR DESCRIPTION
## Problem

On Chrome 115+, the CDP proxy always fails to connect with:

```
Received network error or non-101 status code.
```

This happens because the hardcoded WebSocket path `/devtools/browser` **no longer works** in Chrome 115+. Each Chrome instance now requires a unique browser UUID in the path, e.g.:

```
ws://127.0.0.1:9222/devtools/browser/8d190de1-b82d-403a-b925-effce0f1454f
```

This UUID changes every time Chrome starts and must be fetched from the HTTP `/json/version` endpoint.

The `check-deps.sh` script uses a TCP-only probe (not an actual CDP handshake), so it still reports `chrome: ok` even though the WebSocket connection will fail — making the issue hard to diagnose.

## Fix

Change `getWebSocketUrl()` from a synchronous function returning a hardcoded path to an async function that:

1. Fetches `http://127.0.0.1:{port}/json/version`
2. Extracts `webSocketDebuggerUrl` (which contains the correct UUID)
3. Normalizes `localhost` → `127.0.0.1` for consistency
4. Falls back to the legacy path for older Chromium builds

## Testing

Verified on **Chrome 146.0.7680.154** (macOS, Apple M4 Pro):

- Before fix: proxy reports `connected: false`, all requests return `{"error":"Received network error or non-101 status code."}`
- After fix: proxy reports `connected: true`, CDP commands work correctly