### PR TITLE
fix: fetch WebSocket URL from /json/version for --remote-debugging-port setups

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -101,8 +101,26 @@ function checkPort(port) {
   });
 }
 
-function getWebSocketUrl(port, wsPath) {
+async function getWebSocketUrl(port, wsPath) {
   if (wsPath) return `ws://127.0.0.1:${port}${wsPath}`;
+  // Try /json/version to get the full WebSocket URL with UUID
+  // (needed when Chrome uses --remote-debugging-port without DevToolsActivePort file)
+  try {
+    const resp = await new Promise((resolve, reject) => {
+      const req = http.get(`http://127.0.0.1:${port}/json/version`, { timeout: 3000 }, (res) => {
+        let data = '';
+        res.on('data', c => data += c);
+        res.on('end', () => resolve(data));
+      });
+      req.on('error', reject);
+      req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+    });
+    const info = JSON.parse(resp);
+    if (info.webSocketDebuggerUrl) {
+      console.log(`[CDP Proxy] 从 /json/version 获取 WebSocket URL`);
+      return info.webSocketDebuggerUrl;
+    }
+  } catch { /* fallback */ }
   return `ws://127.0.0.1:${port}/devtools/browser`;
 }
 
@@ -127,7 +145,7 @@ async function connect() {
     chromeWsPath = discovered.wsPath;
   }
 
-  const wsUrl = getWebSocketUrl(chromePort, chromeWsPath);
+  const wsUrl = await getWebSocketUrl(chromePort, chromeWsPath);
   if (!wsUrl) throw new Error('无法获取 Chrome WebSocket URL');
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Problem

When Chrome is launched with `--remote-debugging-port=9333` (a common setup for headless automation / separate debug profiles), the WebSocket debugger URL includes a random UUID path:

```
ws://127.0.0.1:9333/devtools/browser/26590a68-19cd-42e8-bb60-...
```

The current code hardcodes `ws://127.0.0.1:{port}/devtools/browser` (without UUID), which works when Chrome is enabled via `chrome://inspect/#remote-debugging` (which produces a `DevToolsActivePort` file with the path), but silently fails for `--remote-debugging-port` setups — the connection just drops with no actionable error.

## Fix

`getWebSocketUrl()` now first tries `GET http://127.0.0.1:{port}/json/version` to obtain Chrome's `webSocketDebuggerUrl` (which always includes the full path with UUID). Falls back to the hardcoded path if the endpoint is unavailable.

## Changes

- `scripts/cdp-proxy.mjs`: `getWebSocketUrl()` changed from sync to async, added `/json/version` fetch with 3s timeout
- Caller in `connect()` updated to `await`

## Testing

Tested on macOS with Chrome 146 launched via:
```
/Applications/Google\ Chrome.app/.../Google\ Chrome --remote-debugging-port=9333 --remote-allow-origins=* --user-data-dir=~/.chrome-debug-profile
```

Before: `[CDP Proxy] 连接错误: 连接失败`
After: `[CDP Proxy] 从 /json/version 获取 WebSocket URL` → `[CDP Proxy] 已连接 Chrome (端口 9333)`