### PR TITLE
fix: use relative path to locate cdp-proxy.mjs

### DIFF
--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -35,7 +35,8 @@ if echo "$HEALTH" | grep -q '"connected":true'; then
 else
   if ! echo "$HEALTH" | grep -q '"ok"'; then
     echo "proxy: starting..."
-    node ~/.claude/skills/web-access/scripts/cdp-proxy.mjs > /tmp/cdp-proxy.log 2>&1 &
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    node "$SCRIPT_DIR/cdp-proxy.mjs" > /tmp/cdp-proxy.log 2>&1 &
   fi
   for i in $(seq 1 15); do
     sleep 1


### PR DESCRIPTION
## Summary
- `check-deps.sh` hardcoded `~/.claude/skills/web-access/scripts/cdp-proxy.mjs` to start the CDP proxy, which fails when the skill is installed in a project-local `.claude/skills/` directory
- Changed to dynamically resolve the script path relative to `check-deps.sh` itself using `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"`, so it works regardless of installation location

## Test plan
- [ ] Install skill in a project-local `.claude/skills/` directory (not `~/.claude/skills/`)
- [ ] Run `bash .claude/skills/web-access/scripts/check-deps.sh` — proxy should start and connect successfully
- [ ] Verify it still works when installed at `~/.claude/skills/` as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)