### PR TITLE
fix: 修复 current-browser 模式下预检误判浏览器未连接的问题 

### DIFF
--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -15,18 +15,73 @@ else
   exit 1
 fi
 
-# Chrome 调试端口（9222）— TCP 探测，不建立真实连接（跨平台）
-if ! node -e "
+# Chrome 调试端口 — 先读 DevToolsActivePort，再回退常见端口
+if ! CHROME_PORT=$(node -e "
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 const net = require('net');
-const s = net.createConnection(9222, '127.0.0.1');
-s.on('connect', () => { process.exit(0); });
-s.on('error', () => process.exit(1));
-setTimeout(() => process.exit(1), 2000);
-" 2>/dev/null; then
+
+function checkPort(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection(port, '127.0.0.1');
+    const timer = setTimeout(() => { socket.destroy(); resolve(false); }, 2000);
+    socket.once('connect', () => { clearTimeout(timer); socket.destroy(); resolve(true); });
+    socket.once('error', () => { clearTimeout(timer); resolve(false); });
+  });
+}
+
+function activePortFiles() {
+  const home = os.homedir();
+  const localAppData = process.env.LOCALAPPDATA || '';
+  switch (process.platform) {
+    case 'darwin':
+      return [
+        path.join(home, 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
+        path.join(home, 'Library/Application Support/Google/Chrome Canary/DevToolsActivePort'),
+        path.join(home, 'Library/Application Support/Chromium/DevToolsActivePort'),
+      ];
+    case 'linux':
+      return [
+        path.join(home, '.config/google-chrome/DevToolsActivePort'),
+        path.join(home, '.config/chromium/DevToolsActivePort'),
+      ];
+    case 'win32':
+      return [
+        path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
+        path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
+      ];
+    default:
+      return [];
+  }
+}
+
+(async () => {
+  for (const filePath of activePortFiles()) {
+    try {
+      const lines = fs.readFileSync(filePath, 'utf8').trim().split(/\\r?\\n/).filter(Boolean);
+      const port = parseInt(lines[0], 10);
+      if (port > 0 && port < 65536 && await checkPort(port)) {
+        console.log(port);
+        process.exit(0);
+      }
+    } catch (_) {}
+  }
+
+  for (const port of [9222, 9229, 9333]) {
+    if (await checkPort(port)) {
+      console.log(port);
+      process.exit(0);
+    }
+  }
+
+  process.exit(1);
+})();
+" 2>/dev/null); then
   echo "chrome: not connected — 请打开 chrome://inspect/#remote-debugging 并勾选 Allow remote debugging"
   exit 1
 fi
-echo "chrome: ok (port 9222)"
+echo "chrome: ok (port $CHROME_PORT)"
 
 # CDP Proxy — 已运行则跳过，未运行则启动并等待连接
 HEALTH=$(curl -s --connect-timeout 2 "http://127.0.0.1:3456/health" 2>/dev/null)


### PR DESCRIPTION

### 背景

当前 current-browser 模式下，代理本身可以通过 DevToolsActivePort 连上浏览器。

但预检脚本 check-deps.sh 只会探测 127.0.0.1:9222。

如果 Chrome 实际使用的是动态调试端口，预检就会先报浏览器未连接，和代理的真实可用状态不一致。

下面这张图就是本机 DevToolsActivePort 文件内容截图，当前端口是 61808。

<img width="1905" height="1110" alt="devtools-active-port-current-browser-61808" src="https://github.com/user-attachments/assets/c352a16e-557d-4bd7-bb07-fc6f18a44480" />

### 为什么这样改

原来的逻辑是直接探测 9222。

```bash
# 原来的问题在这里：端口直接写死成 9222
if ! node -e "
const net = require('net');
const s = net.createConnection(9222, '127.0.0.1');
s.on('connect', () => { process.exit(0); });
s.on('error', () => process.exit(1));
setTimeout(() => process.exit(1), 2000);
" 2>/dev/null; then
  echo "chrome: not connected — 请打开 chrome://inspect/#remote-debugging 并勾选 Allow remote debugging"
  exit 1
fi

# 这里也有同样的问题：成功后仍然固定输出 9222
echo "chrome: ok (port 9222)"
```

现在改成先读真实端口，再回退常见端口。

```bash
# 这里是这次的改动：先尝试从 DevToolsActivePort 读取真实端口
if ! CHROME_PORT=$(node -e "
const fs = require('fs');
const path = require('path');
const os = require('os');
const net = require('net');

function checkPort(port) {
  return new Promise((resolve) => {
    const socket = net.createConnection(port, '127.0.0.1');
    const timer = setTimeout(() => { socket.destroy(); resolve(false); }, 2000);
    socket.once('connect', () => { clearTimeout(timer); socket.destroy(); resolve(true); });
    socket.once('error', () => { clearTimeout(timer); resolve(false); });
  });
}

function activePortFiles() {
  const home = os.homedir();
  const localAppData = process.env.LOCALAPPDATA || '';
  switch (process.platform) {
    case 'win32':
      return [
        path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
        path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
      ];
    default:
      return [];
  }
}

(async () => {
  for (const filePath of activePortFiles()) {
    try {
      const lines = fs.readFileSync(filePath, 'utf8').trim().split(/\\r?\\n/).filter(Boolean);
      const port = parseInt(lines[0], 10);
      if (port > 0 && port < 65536 && await checkPort(port)) {
        console.log(port); // 这里输出真实发现到的端口
        process.exit(0);
      }
    } catch (_) {}
  }

  // 这里是回退逻辑：读不到活动端口时，再试常见端口
  for (const port of [9222, 9229, 9333]) {
    if (await checkPort(port)) {
      console.log(port);
      process.exit(0);
    }
  }

  process.exit(1);
})();
" 2>/dev/null); then
  echo "chrome: not connected — 请打开 chrome://inspect/#remote-debugging 并勾选 Allow remote debugging"
  exit 1
fi

# 这里也是这次的改动：输出真实发现到的端口
echo "chrome: ok (port $CHROME_PORT)"
```

### 现在改了什么

这次只改了 check-deps.sh。

预检现在会先读取 Chrome 或 Chromium 用户目录里的 DevToolsActivePort，拿到端口后再做 TCP 连通性确认。

如果读不到，再回退去试几个常见端口。

另外，预检成功时输出的也改成了真实发现到的端口，不再固定显示 9222。

### 注意事项

本代码仅仅在Windows上面测试，并测试成功。
其他系统由于没有机器所以未进行测试。
