### PR TITLE
fix: CDP Proxy 兼容 --remote-debugging-port 方式连接 Chrome

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -101,8 +101,30 @@ function checkPort(port) {
   });
 }
 
-function getWebSocketUrl(port, wsPath) {
+async function getWebSocketUrl(port, wsPath) {
   if (wsPath) return `ws://127.0.0.1:${port}${wsPath}`;
+
+  // For --remote-debugging-port launched Chrome, fetch the full WebSocket URL
+  // from /json/version which includes the required browser UUID
+  try {
+    const url = await new Promise((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/json/version`, { timeout: 3000 }, (res) => {
+        let data = '';
+        res.on('data', c => data += c);
+        res.on('end', () => {
+          try {
+            const json = JSON.parse(data);
+            resolve(json.webSocketDebuggerUrl || null);
+          } catch { resolve(null); }
+        });
+      }).on('error', () => resolve(null));
+    });
+    if (url) {
+      console.log(`[CDP Proxy] 从 /json/version 获取 WebSocket URL`);
+      return url;
+    }
+  } catch { /* fall through */ }
+
   return `ws://127.0.0.1:${port}/devtools/browser`;
 }
 
@@ -127,7 +149,7 @@ async function connect() {
     chromeWsPath = discovered.wsPath;
   }
 
-  const wsUrl = getWebSocketUrl(chromePort, chromeWsPath);
+  const wsUrl = await getWebSocketUrl(chromePort, chromeWsPath);
   if (!wsUrl) throw new Error('无法获取 Chrome WebSocket URL');
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## 问题

当 Chrome 通过 `--remote-debugging-port=9222` 启动时，CDP Proxy 连接失败，报错 `non-101 status code`。

**原因**：`--remote-debugging-port` 启动的 Chrome，WebSocket 端点需要带 browser UUID（如 `ws://127.0.0.1:9222/devtools/browser/99dadaa3-...`）。cdp-proxy 在扫描端口发现 Chrome 后，使用的是裸路径 `ws://127.0.0.1:9222/devtools/browser`，被 Chrome 拒绝。

`chrome://inspect` 方式不受影响，因为 DevToolsActivePort 文件已包含完整 wsPath。

## 修复

在 `getWebSocketUrl` 中，当 `wsPath` 不可用时，先通过 Chrome 的 `/json/version` HTTP API 获取完整的 `webSocketDebuggerUrl`，再回退到裸路径。

```
扫描端口 → /json/version → webSocketDebuggerUrl（带 UUID） → 连接成功
```

## 兼容性

两种连接方式现在都能正常工作：

| 方式 | 发现端口 | 获取 wsPath | 状态 |
|------|---------|------------|------|
| `chrome://inspect` 勾选 | DevToolsActivePort 文件 | 文件第二行 | 已有，不受影响 |
| `--remote-debugging-port=9222` | 端口扫描 | `/json/version` API | **本 PR 修复** |

## 测试

```
[CDP Proxy] 运行在 http://localhost:3456
[CDP Proxy] 扫描发现 Chrome 调试端口: 9222
[CDP Proxy] 从 /json/version 获取 WebSocket URL
[CDP Proxy] 已连接 Chrome (端口 9222)
```

改动仅 1 个文件，24 行新增。