### PR TITLE
fix: 改进 preflight 重连

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -262,6 +262,16 @@ const server = http.createServer(async (req, res) => {
   try {
     // /health 不需要连接 Chrome
     if (pathname === '/health') {
+      const shouldReconnect = q.reconnect === '1';
+      const connectedBefore = ws && (ws.readyState === WS.OPEN || ws.readyState === 1);
+
+      // 允许健康检查顺手触发一次重连，便于 check-deps.sh 唤起 Chrome 授权弹窗。
+      if (shouldReconnect && !connectedBefore) {
+        try {
+          await connect();
+        } catch { /* 保持 health 接口稳定返回，由调用方决定是否继续等待 */ }
+      }
+
       const connected = ws && (ws.readyState === WS.OPEN || ws.readyState === 1);
       res.end(JSON.stringify({ status: 'ok', connected, sessions: sessions.size, chromePort }));
       return;

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -93,9 +93,15 @@ else
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
     node "$SCRIPT_DIR/cdp-proxy.mjs" > /tmp/cdp-proxy.log 2>&1 &
   fi
-  for i in $(seq 1 15); do
+  PROXY_HINT_SHOWN=0
+  for i in $(seq 1 30); do
     sleep 1
-    curl -s http://localhost:3456/health | grep -q '"connected":true' && echo "proxy: ready" && exit 0
+    HEALTH=$(curl -s --connect-timeout 2 "http://127.0.0.1:3456/health?reconnect=1" 2>/dev/null)
+    echo "$HEALTH" | grep -q '"connected":true' && echo "proxy: ready" && exit 0
+    if [ $PROXY_HINT_SHOWN -eq 0 ] && echo "$HEALTH" | grep -q '"ok"'; then
+      echo "proxy: waiting for Chrome authorization..."
+      PROXY_HINT_SHOWN=1
+    fi
     [ $i -eq 3 ] && echo "⚠️  Chrome 可能有授权弹窗，请点击「允许」后等待连接..."
   done
   echo "❌ 连接超时，请检查 Chrome 调试设置"


### PR DESCRIPTION
## 概要
- 在 proxy 已运行但尚未附着到 Chrome 时，允许通过 `/health` 触发一次重连
- 让 `check-deps.sh` 在等待授权期间主动重试连接，而不是只轮询断开的旧状态
- 适当延长等待时间，并在等待 Chrome 授权弹窗时输出更明确的提示

## 问题
当 `cdp-proxy.mjs` 已经在运行，但此前与 Chrome 的连接没有建立成功时，`check-deps.sh` 只会轮询 `/health` 中的 `"connected":true`。

在这个状态下，脚本不会再次主动发起新的 WebSocket 连接尝试，因此 Chrome 不会重新弹出远程调试授权对话框。结果就是，即使 `9222` 端口已经可用，preflight 检查仍然会一直等待，最后超时失败。

## 复现方式
1. 在 Chrome 中开启 remote debugging。
2. 让 proxy 处于“进程已运行但未连接 Chrome”的状态。
3. 执行 `bash ~/.claude/skills/web-access/scripts/check-deps.sh`。
4. 可以看到脚本提示等待授权，但不会触发新的授权弹窗，最终超时退出。

## 验证
- 在本地复现了 Chrome 监听 `9222`、proxy 处于断连状态时的超时问题
- 应用改动后重新执行 `bash ~/.claude/skills/web-access/scripts/check-deps.sh`，已确认可以到达 `proxy: ready`
- 已确认本次改动仅涉及 `scripts/check-deps.sh` 和 `scripts/cdp-proxy.mjs`

## 说明
本次修改不会改变现有 proxy 常驻运行的模型，只是增强了 preflight 阶段的重连能力，以便补上触发 Chrome 授权弹窗所需的连接步骤。