### PR TITLE
fix: fetch wsPath from /json/version when port scanning

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -82,8 +82,9 @@ async function discoverChromePort() {
   for (const port of commonPorts) {
     const ok = await checkPort(port);
     if (ok) {
-      console.log(`[CDP Proxy] 扫描发现 Chrome 调试端口: ${port}`);
-      return { port, wsPath: null };
+      const wsPath = await fetchWsPath(port);
+      console.log(`[CDP Proxy] 扫描发现 Chrome 调试端口: ${port}${wsPath ? ' (带 wsPath)' : ''}`);
+      return { port, wsPath };
     }
   }
 
@@ -98,6 +99,27 @@ function checkPort(port) {
     const timer = setTimeout(() => { socket.destroy(); resolve(false); }, 2000);
     socket.once('connect', () => { clearTimeout(timer); socket.destroy(); resolve(true); });
     socket.once('error', () => { clearTimeout(timer); resolve(false); });
+  });
+}
+
+// 从 /json/version 获取带 UUID 的 WebSocket 路径
+// Chrome 在非 --remote-debugging-port 模式下只接受带 UUID 的路径，拒绝裸 /devtools/browser
+// 使用顶层已 import 的 http 模块，无需 require()
+function fetchWsPath(port) {
+  return new Promise((resolve) => {
+    http.get(`http://127.0.0.1:${port}/json/version`, { timeout: 2000 }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const info = JSON.parse(data);
+          const wsUrl = info.webSocketDebuggerUrl;
+          resolve(wsUrl ? new URL(wsUrl).pathname : null);
+        } catch {
+          resolve(null);
+        }
+      });
+    }).on('error', () => resolve(null));
   });
 }
 


### PR DESCRIPTION
## Problem

Fixes #10

When Chrome is discovered via port scanning (the fallback path when `DevToolsActivePort` is absent or stale), `discoverChromePort()` returns `{ port, wsPath: null }`. This causes `getWebSocketUrl()` to produce a bare `ws://127.0.0.1:9222/devtools/browser` URL without a UUID, which Chrome rejects with a `non-101 status code`.

The issue description mentions a `getChromeWebSocketUrl()` function that used `require('node:http')` in an ES module context. While that specific function no longer exists in the current code, the underlying problem remains: port scanning never retrieves the real WebSocket path from Chrome.

## Fix

Add `fetchWsPath(port)` — a small helper that calls `http://127.0.0.1:${port}/json/version` and extracts the `webSocketDebuggerUrl` pathname. It uses the **already top-level-imported `http` module**, so no `require()` is needed.

Call `fetchWsPath()` in the port scanning branch of `discoverChromePort()`, so the returned `wsPath` contains the UUID path whenever Chrome exposes one.

## Behavior

| Scenario | Before | After |
|---|---|---|
| `DevToolsActivePort` present | wsPath from file ✅ | unchanged ✅ |
| Port scan hits Chrome | `wsPath: null` → connection fails ❌ | `wsPath` from `/json/version` → connects ✅ |
| `/json/version` unavailable | — | gracefully falls back to `null` (existing behavior) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)