### PR TITLE
fix: use ${CLAUDE_SKILL_DIR} instead of hardcoded path in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 在开始联网操作前，先检查 CDP 模式可用性：
 
 ```bash
-bash ~/.claude/skills/web-access/scripts/check-deps.sh
+bash ${CLAUDE_SKILL_DIR}/scripts/check-deps.sh
 ```
 
 - **Node.js 22+**：必需（使用原生 WebSocket）。版本低于 22 可用但需安装 `ws` 模块。
@@ -82,7 +82,7 @@ bash ~/.claude/skills/web-access/scripts/check-deps.sh
 ### 启动
 
 ```bash
-bash ~/.claude/skills/web-access/scripts/check-deps.sh
+bash ${CLAUDE_SKILL_DIR}/scripts/check-deps.sh
 ```
 
 脚本会依次检查 Node.js、Chrome 端口，并确保 Proxy 已连接（未运行则自动启动并等待）。Proxy 启动后持续运行。


### PR DESCRIPTION
Replace hardcoded `~/.claude/skills/web-access/scripts/check-deps.sh` with `${CLAUDE_SKILL_DIR}/scripts/check-deps.sh` so the script path resolves correctly regardless of where the skill is installed (personal, project, or plugin directory).