### PR TITLE
fix: clear cached chrome port on WebSocket connection error

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -144,8 +144,11 @@ async function connect() {
     const onError = (e) => {
       cleanup();
       connectingPromise = null;
+      ws = null;
+      chromePort = null;
+      chromeWsPath = null;
       const msg = e.message || e.error?.message || '连接失败';
-      console.error('[CDP Proxy] 连接错误:', msg);
+      console.error('[CDP Proxy] 连接错误:', msg, '（端口缓存已清除，下次将重新发现）');
       reject(new Error(msg));
     };
     const onClose = () => {


### PR DESCRIPTION
## Summary
- When `connect()` fails (e.g. connecting to a Docker port instead of Chrome), `chromePort` was not reset — causing all subsequent requests to keep retrying the wrong port
- Now `onError` clears `ws`, `chromePort`, and `chromeWsPath` (matching `onClose` behavior), so the next request re-discovers the correct Chrome port

## Reproduction
1. Start Docker (or anything) on port 9333
2. Start CDP proxy — it discovers 9333 and caches it
3. Start Chrome with `--remote-debugging-port=9222`
4. All `/targets` requests fail because proxy keeps connecting to 9333

After this fix, step 4 would clear the cache and re-discover port 9222.

## Test plan
- [ ] Start proxy without Chrome running, verify it retries with fresh discovery on each request
- [ ] Start proxy with wrong port cached, then start Chrome — verify next request finds Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)