### PR TITLE
feat: 增加 Windows 下的 check-deps 支持

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -14,11 +14,12 @@ metadata:
 
 ## 前置检查
 
+执行下面任何本地命令前，先判断本地 OS。Windows 使用 PowerShell 版本，其他系统沿用当前命令。
+
 在开始联网操作前，先检查 CDP 模式可用性：
 
-```bash
-bash ~/.claude/skills/web-access/scripts/check-deps.sh
-```
+- Windows：`powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\web-access\scripts\check-deps.ps1"`
+- 其他系统：`bash ~/.claude/skills/web-access/scripts/check-deps.sh`
 
 - **Node.js 22+**：必需（使用原生 WebSocket）。版本低于 22 可用但需安装 `ws` 模块。
 - **Chrome remote-debugging**：在 Chrome 地址栏打开 `chrome://inspect/#remote-debugging`，勾选 **"Allow remote debugging for this browser instance"** 即可，可能需要重启浏览器。
@@ -81,11 +82,10 @@ bash ~/.claude/skills/web-access/scripts/check-deps.sh
 
 ### 启动
 
-```bash
-bash ~/.claude/skills/web-access/scripts/check-deps.sh
-```
+- Windows：`powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.claude\skills\web-access\scripts\check-deps.ps1"`
+- 其他系统：`bash ~/.claude/skills/web-access/scripts/check-deps.sh`
 
-脚本会依次检查 Node.js、Chrome 端口，并确保 Proxy 已连接（未运行则自动启动并等待）。Proxy 启动后持续运行。
+脚本会依次检查 Node.js、Chrome 端口（优先 DevToolsActivePort，失败则回退常用端口），并确保 Proxy 已连接（未运行则自动启动并等待）。Proxy 启动后持续运行。
 
 ### Proxy API
 
@@ -127,6 +127,8 @@ curl -s "http://localhost:3456/scroll?target=ID&direction=bottom"
 # 关闭 tab
 curl -s "http://localhost:3456/close?target=ID"
 ```
+
+Windows 下涉及本地文件路径的示例，请把 `/tmp/...` 这类路径改成 `$env:TEMP\...` 或实际 Windows 路径。
 
 ### 页面内导航
 
@@ -211,7 +213,9 @@ Proxy 持续运行，不建议主动停止——重启后需要在 Chrome 中重
 
 操作中积累的特定网站经验，按域名存储在 `references/site-patterns/` 下。
 
-已有经验的站点：!`ls ${CLAUDE_SKILL_DIR}/references/site-patterns/ 2>/dev/null | sed 's/\.md$//' || echo "暂无"`
+已有经验的站点：
+- Windows：`Get-ChildItem -File "$env:CLAUDE_SKILL_DIR\references\site-patterns" -Filter '*.md' -ErrorAction SilentlyContinue | ForEach-Object { $_.BaseName }`
+- 其他系统：`ls ${CLAUDE_SKILL_DIR}/references/site-patterns/ 2>/dev/null | sed 's/\.md$//' || echo "暂无"`
 
 确定目标网站后，如果上方列表中有匹配的站点，必须读取对应文件获取先验知识（平台特征、有效模式、已知陷阱）。经验内容标注了发现日期，当作可能有效的提示而非保证——如果按经验操作失败，回退通用模式并更新经验文件。
 

--- a/scripts/check-deps.ps1
+++ b/scripts/check-deps.ps1
@@ -1,0 +1,168 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+
+function Initialize-TerminalEncoding {
+  $codePage = 0
+
+  try {
+    $codePage = [Console]::OutputEncoding.CodePage
+  } catch {
+    $codePage = 0
+  }
+
+  if ($codePage -le 0) {
+    $codePage = [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.OEMCodePage
+  }
+
+  try {
+    $encoding = [System.Text.Encoding]::GetEncoding($codePage)
+  } catch {
+    $encoding = [System.Text.Encoding]::UTF8
+  }
+
+  [Console]::InputEncoding = $encoding
+  [Console]::OutputEncoding = $encoding
+  $OutputEncoding = $encoding
+}
+
+Initialize-TerminalEncoding
+
+function Test-Port {
+  param(
+    [int]$Port
+  )
+
+  try {
+    $client = [System.Net.Sockets.TcpClient]::new()
+    $iar = $client.BeginConnect('127.0.0.1', $Port, $null, $null)
+    if (-not $iar.AsyncWaitHandle.WaitOne(2000)) {
+      $client.Close()
+      return $false
+    }
+
+    $client.EndConnect($iar)
+    $client.Close()
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Get-ActivePortFiles {
+  $userProfile = [Environment]::GetFolderPath('UserProfile')
+
+  if ($IsMacOS) {
+    return @(
+      (Join-Path $userProfile 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
+      (Join-Path $userProfile 'Library/Application Support/Google/Chrome Canary/DevToolsActivePort'),
+      (Join-Path $userProfile 'Library/Application Support/Chromium/DevToolsActivePort')
+    )
+  }
+
+  if ($IsLinux) {
+    return @(
+      (Join-Path $userProfile '.config/google-chrome/DevToolsActivePort'),
+      (Join-Path $userProfile '.config/chromium/DevToolsActivePort')
+    )
+  }
+
+  if ($env:OS -eq 'Windows_NT') {
+    $localAppData = $env:LOCALAPPDATA
+    return @(
+      (Join-Path $localAppData 'Google/Chrome/User Data/DevToolsActivePort'),
+      (Join-Path $localAppData 'Chromium/User Data/DevToolsActivePort')
+    )
+  }
+
+  return @()
+}
+
+function Get-Targets {
+  try {
+    return (Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 'http://127.0.0.1:3456/targets').Content
+  } catch {
+    return $null
+  }
+}
+
+$nodeCmd = Get-Command -Name node -ErrorAction SilentlyContinue
+if (-not $nodeCmd) {
+  Write-Output 'node: missing — 请安装 Node.js 22+'
+  exit 1
+}
+
+$nodeVer = & node --version 2>$null
+$nodeMajor = [int](($nodeVer.TrimStart('v')).Split('.')[0])
+if ($nodeMajor -ge 22) {
+  Write-Output "node: ok ($nodeVer)"
+} else {
+  Write-Output "node: warn ($nodeVer, 建议升级到 22+)"
+}
+
+$chromePort = $null
+foreach ($filePath in Get-ActivePortFiles) {
+  if (-not (Test-Path -LiteralPath $filePath)) {
+    continue
+  }
+
+  try {
+    $lines = Get-Content -LiteralPath $filePath -ErrorAction Stop
+    if ($lines.Count -eq 0) {
+      continue
+    }
+
+    $port = [int]$lines[0]
+    if ($port -gt 0 -and $port -lt 65536 -and (Test-Port -Port $port)) {
+      $chromePort = $port
+      break
+    }
+  } catch {
+    continue
+  }
+}
+
+if (-not $chromePort) {
+  foreach ($port in 9222, 9229, 9333) {
+    if (Test-Port -Port $port) {
+      $chromePort = $port
+      break
+    }
+  }
+}
+
+if (-not $chromePort) {
+  Write-Output 'chrome: not connected — 请打开 chrome://inspect/#remote-debugging 并勾选 Allow remote debugging'
+  exit 1
+}
+
+Write-Output "chrome: ok (port $chromePort)"
+
+$targets = Get-Targets
+if ($targets -and $targets.TrimStart().StartsWith('[')) {
+  Write-Output 'proxy: ready'
+  exit 0
+}
+
+Write-Output 'proxy: connecting...'
+$scriptDir = $PSScriptRoot
+$stdoutLog = Join-Path $env:TEMP 'cdp-proxy.out.log'
+$stderrLog = Join-Path $env:TEMP 'cdp-proxy.err.log'
+Start-Process -FilePath 'node' -ArgumentList @((Join-Path $scriptDir 'cdp-proxy.mjs')) -WorkingDirectory $scriptDir -WindowStyle Hidden -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog | Out-Null
+Start-Sleep -Seconds 2
+
+for ($i = 1; $i -le 15; $i++) {
+  $targets = Get-Targets
+  if ($targets -and $targets.TrimStart().StartsWith('[')) {
+    Write-Output 'proxy: ready'
+    exit 0
+  }
+
+  if ($i -eq 1) {
+    Write-Output '⚠️  Chrome 可能有授权弹窗，请点击「允许」后等待连接...'
+  }
+
+  Start-Sleep -Seconds 1
+}
+
+Write-Output '❌ 连接超时，请检查 Chrome 调试设置'
+exit 1


### PR DESCRIPTION
  ## 变更说明
  为 web-access skill 增加 Windows 下的 PowerShell 入口，补齐依赖检查与 CDP 启动流程。

  ## 为什么需要
  原来的检查脚本是 Bash 版本，Windows 用户无法直接使用同一套前置检查流程。

  ## 具体改动
  - 新增 `scripts/check-deps.ps1`
  - 在 Windows 下安全检测 `node` 是否存在
  - 补回 Chrome 调试端口的常用回退逻辑
  - 更新 `SKILL.md`，补充 Windows 启动方式和说明

  ## 验证方式
  - 已通过 PowerShell 语法解析
  - 确认改动范围仅为 `SKILL.md` 和 `scripts/check-deps.ps1`

  ## 备注
  该改动只补充 Windows 支持，不影响 Linux / macOS 原有路径。