### PR TITLE
Add Codex-compatible web-access skill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,40 @@
-<div align="right">
-  <details>
-    <summary>🌐 Language</summary>
-    <div>
-      <div align="center">
-        <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=en">English</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=zh-CN">简体中文</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=zh-TW">繁體中文</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=ja">日本語</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=ko">한국어</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=fr">Français</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=de">Deutsch</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=es">Español</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=pt">Português</a>
-        | <a href="https://openaitx.github.io/view.html?user=eze-is&project=web-access&lang=ru">Русский</a>
-      </div>
-    </div>
-  </details>
-</div>
+# web-access for Codex
 
-<img width="879" height="376" alt="image" src="https://github.com/user-attachments/assets/a87fd816-a0b5-4264-b01c-9466eae90723" />
+This branch adds a Codex-native port of the upstream repository while preserving the existing browser-proxy workflow.
 
-给 Claude Code 装上完整联网能力的 skill。
+- upstream repository: `https://github.com/eze-is/web-access`
+- Codex install path: `~/.codex/skills/web-access`
 
-Claude Code 原本有 WebSearch、WebFetch，但缺少调度策略和浏览器自动化能力。这个 skill 补上的是：**联网策略 + CDP 浏览器操作 + 站点经验积累**。
+## What is preserved
 
-> 推荐必读：[Web Access：一个 Skill，拉满 Agent 联网和浏览器能力](https://mp.weixin.qq.com/s/rps5YVB6TchT9npAaIWKCw) ，完整介绍了 Web-Access Skill 的开发细节与 Agent Skill 设计哲学，帮助你也能写出类似通用、高上限的 Skill
+- local Chrome CDP proxy
+- authenticated browsing through the user's Chrome session
+- site-pattern knowledge files
+- browser-side extraction workflows
+- parallel browser research guidance for independent targets
 
----
+## Codex-specific changes
 
-## v2.4.1 能力
+- `SKILL.md` is rewritten for Codex skill triggering and tool routing
+- shell examples use `~/.codex/skills/web-access/...`
+- the CDP proxy now resolves Chrome's full `webSocketDebuggerUrl` through `/json/version` when needed
+- `agents/openai.yaml` is added for Codex UI metadata
 
-| 能力 | 说明 |
-|------|------|
-| 联网工具自动选择 | WebSearch / WebFetch / curl / Jina / CDP，按场景自主判断，可任意组合 |
-| CDP Proxy 浏览器操作 | 直连用户日常 Chrome，天然携带登录态，支持动态页面、交互操作、视频截帧 |
-| 三种点击方式 | `/click`（JS click）、`/clickAt`（CDP 真实鼠标事件）、`/setFiles`（文件上传） |
-| 并行分治 | 多目标时分发子 Agent 并行执行，共享一个 Proxy，tab 级隔离 |
-| 站点经验积累 | 按域名存储操作经验（URL 模式、平台特征、已知陷阱），跨 session 复用 |
-| 媒体提取 | 从 DOM 直取图片/视频 URL，或对视频任意时间点截帧分析 |
-
-**v2.4.1 更新：**
-- **跨平台支持** — 脚本从 bash 迁移到 Node.js，Windows / Linux / macOS 均可使用
-- **DOM 边界穿透** — 新增技术事实：eval 递归遍历可穿透 Shadow DOM、iframe 等选择器不可跨越的边界
-
-<details><summary>v2.4 更新</summary>
-
-- **站点内 URL 可靠性** — 新增事实说明：站点生成的链接自带完整上下文，手动构造的 URL 可能缺失隐式必要参数
-- **平台错误提示不可信** — 新增技术事实：平台返回的"内容不存在"等提示可能是访问方式问题而非内容本身问题
-- **小红书站点经验增强** — xsec_token 机制、创作者平台状态校验、暂存草稿流程
-</details>
-
-<details><summary>v2.3 更新</summary>
-
-- **浏览哲学重构** — 更清晰的「像人一样思考」框架，强调目标驱动而非步骤驱动
-- **Jina 积极推荐** — 明确鼓励在合适场景主动使用 Jina 节省 token
-- **子 Agent prompt 指引优化** — 明确加载写法，增加避免动词暗示执行方式的说明
-</details>
-
-## 安装
-
-**方式一：让 Claude 自动安装**
-
-```
-帮我安装这个 skill：https://github.com/eze-is/web-access
-```
-
-**方式二：Plugin 安装**
+## Start the proxy
 
 ```bash
-claude plugin marketplace add https://github.com/eze-is/web-access
-claude plugin install web-access@web-access --scope user
+node ~/.codex/skills/web-access/scripts/check-deps.mjs
 ```
 
-**方式三：手动**
+## Key scripts
 
-```bash
-git clone https://github.com/eze-is/web-access ~/.claude/skills/web-access
-```
+- `scripts/check-deps.mjs`
+- `scripts/cdp-proxy.mjs`
+- `scripts/match-site.mjs`
+- `scripts/list-site-patterns.mjs`
 
-## 前置配置（CDP 模式）
+## References
 
-CDP 模式需要 **Node.js 22+** 和 Chrome 开启远程调试：
-
-1. Chrome 地址栏打开 `chrome://inspect/#remote-debugging`
-2. 勾选 **Allow remote debugging for this browser instance**（可能需要重启浏览器）
-
-环境检查（Agent 运行时会自动完成前置检查，无需手动执行）：
-
-```bash
-node "$CLAUDE_SKILL_DIR/scripts/check-deps.mjs"
-# $CLAUDE_SKILL_DIR 是 skill 加载时自动设置的环境变量
-# 手动运行请替换为实际路径，如 ~/.claude/skills/web-access
-```
-
-## CDP Proxy API
-
-Proxy 通过 WebSocket 直连 Chrome（兼容 `chrome://inspect` 方式，无需命令行参数启动），提供 HTTP API：
-
-```bash
-# 启动（Agent 会自动管理 Proxy 生命周期，无需手动启动）
-node "$CLAUDE_SKILL_DIR/scripts/cdp-proxy.mjs" &
-
-# 页面操作
-curl -s "http://localhost:3456/new?url=https://example.com"     # 新建 tab
-curl -s -X POST "http://localhost:3456/eval?target=ID" -d 'document.title'  # 执行 JS
-curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'  # JS 点击
-curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d '.upload-btn'  # 真实鼠标点击
-curl -s -X POST "http://localhost:3456/setFiles?target=ID" \
-  -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'        # 文件上传
-curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"     # 截图
-curl -s "http://localhost:3456/scroll?target=ID&direction=bottom"           # 滚动
-curl -s "http://localhost:3456/close?target=ID"                             # 关闭 tab
-```
-
-## ⚠️ 使用前提醒
-
-通过浏览器自动化操作社交平台（如小红书）存在账号被平台限流或封禁的风险。**强烈建议使用小号进行操作。**
-
-## 使用
-
-安装后直接让 Agent 执行联网任务，skill 自动接管：
-
-- "帮我搜索 xxx 最新进展"
-- "读一下这个页面：[URL]"
-- "去小红书搜索 xxx 的账号"
-- "帮我在创作者平台发一篇图文"
-- "同时调研这 5 个产品的官网，给我对比摘要"
-
-## 设计哲学
-
-> Skill = 哲学 + 技术事实，不是操作手册。讲清 tradeoff 让 AI 自己选，不替它推理。
-
-详见 [SKILL.md](./SKILL.md) 中的浏览哲学部分。
-
-## License
-
-MIT · 作者：[一泽 Eze](https://github.com/eze-is)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=eze-is/web-access&type=Date)](https://star-history.com/#eze-is/web-access&Date)
-
-<img width="1280" height="306" alt="image" src="https://github.com/user-attachments/assets/2afa25c2-3730-413e-b40f-94e52567249d" />
+- `SKILL.md`
+- `references/cdp-api.md`
+- `references/site-patterns/`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,248 +1,202 @@
 ---
 name: web-access
-license: MIT
-github: https://github.com/eze-is/web-access
-description:
-  所有联网操作必须通过此 skill 处理，包括：搜索、网页抓取、登录后操作、网络交互等。
-  触发场景：用户要求搜索信息、查看网页内容、访问需要登录的网站、操作网页界面、抓取社交媒体内容（小红书、微博、推特等）、读取动态渲染页面、以及任何需要真实浏览器环境的网络任务。
+description: End-to-end web research and browser automation through Codex web tools, curl, and a local Chrome CDP proxy. Use when Codex needs to search the web, inspect or extract webpage content, access dynamic or authenticated sites, operate a real browser tab, reuse site-specific patterns, capture media, or coordinate parallel browser research across independent targets when the user explicitly asks for delegation or parallel work.
 metadata:
-  author: 一泽Eze
-  version: "2.4.1"
+  author: eze-is
+  version: "2.4.1-codex"
 ---
 
-# web-access Skill
+# Web Access for Codex
 
-## 前置检查
+Use this skill as a Codex-native port of the upstream `eze-is/web-access` repository.
+Preserve the upstream behavior and decision logic, but adapt the execution model to Codex:
 
-在开始联网操作前，先检查 CDP 模式可用性：
+- Codex reads `SKILL.md` first.
+- Codex does not auto-run bundled `.mjs` files.
+- Run bundled scripts explicitly through the shell when the workflow calls for them.
 
-```bash
-node "$CLAUDE_SKILL_DIR/scripts/check-deps.mjs"
-```
+## Required startup for CDP work
 
-未通过时引导用户完成设置：
-- **Node.js 22+**：必需（使用原生 WebSocket）。版本低于 22 可用但需安装 `ws` 模块。
-- **Chrome remote-debugging**：在 Chrome 地址栏打开 `chrome://inspect/#remote-debugging`，勾选 **"Allow remote debugging for this browser instance"** 即可，可能需要重启浏览器。
-
-检查通过后并必须在回复中向用户直接展示以下须知，再启动 CDP Proxy 执行操作：
-
-```
-温馨提示：部分站点对浏览器自动化操作检测严格，存在账号封禁风险。已内置防护措施但无法完全避免，Agent 继续操作即视为接受。
-```
-
-## 浏览哲学
-
-**像人一样思考，兼顾高效与适应性的完成任务。**
-
-执行任务时不会过度依赖固有印象所规划的步骤，而是带着目标进入，边看边判断，遇到阻碍就解决，发现内容不够就深入——全程围绕「我要达成什么」做决策。这个 skill 的所有行为都应遵循这个逻辑。
-
-**① 拿到请求** — 先明确用户要做什么，定义成功标准：什么算完成了？需要获取什么信息、执行什么操作、达到什么结果？这是后续所有判断的锚点。
-
-**② 选择起点** — 根据任务性质、平台特征、达成条件，选一个最可能直达的方式作为第一步去验证。一次成功当然最好；不成功则在③中调整。比如，需要操作页面、需要登录态、已知静态方式不可达的平台（小红书、微信公众号等）→ 直接 CDP
-
-**③ 过程校验** — 每一步的结果都是证据，不只是成功或失败的二元信号。用结果对照①的成功标准，更新你对目标的判断：路径在推进吗？结果的整体面貌（质量、相关度、量级）是否指向目标可达？发现方向错了立即调整，不在同一个方式上反复重试——搜索没命中不等于"还没找对方法"，也可能是"目标不存在"；API 报错、页面缺少预期元素、重试无改善，都是在告诉你该重新评估方向。遇到弹窗、登录墙等障碍，判断它是否真的挡住了目标：挡住了就处理，没挡住就绕过——内容可能已在页面 DOM 中，交互只是展示手段。
-
-**④ 完成判断** — 对照定义的任务成功标准，确认任务完成后才停止，但也不要过度操作，不为了"完整"而浪费代价。
-
-## 联网工具选择
-
-- **确保信息的真实性，一手信息优于二手信息**：搜索引擎和聚合平台是信息发现入口。当多次搜索尝试后没有质的改进时，升级到更根本的获取方式：定位一手来源（官网、官方平台、原始页面）。
-
-| 场景 | 工具 |
-|------|------|
-| 搜索摘要或关键词结果，发现信息来源 | **WebSearch** |
-| URL 已知，需要从页面定向提取特定信息 | **WebFetch**（拉取网页内容，由小模型根据 prompt 提取，返回处理后结果） |
-| URL 已知，需要原始 HTML 源码（meta、JSON-LD 等结构化字段） | **curl** |
-| 非公开内容，或已知静态层无效的平台（小红书、微信公众号等公开内容也被反爬限制） | **浏览器 CDP**（直接，跳过静态层） |
-| 需要登录态、交互操作，或需要像人一样在浏览器内自由导航探索 | **浏览器 CDP** |
-
-浏览器 CDP 不要求 URL 已知——可从任意入口出发，通过页面内搜索、点击、跳转等方式找到目标内容。WebSearch、WebFetch、curl 均不处理登录态。
-
-**Jina**（可选预处理层，可与 WebFetch/curl 组合使用，由于其特性可节省 tokens 消耗，请积极在任务合适时组合使用）：第三方网络服务，可将网页转为 Markdown，大幅节省 token 但可能有信息损耗。调用方式为 `r.jina.ai/example.com`（URL 前加前缀，不保留原网址 http 前缀），限 20 RPM。适合文章、博客、文档、PDF 等以正文为核心的页面；对数据面板、商品页等非文章结构页面可能提取到错误区块。
-
-进入浏览器层后，`/eval` 就是你的眼睛和手：
-
-- **看**：用 `/eval` 查询 DOM，发现页面上的链接、按钮、表单、文本内容——相当于「看看这个页面有什么」
-- **做**：用 `/click` 点击元素、`/scroll` 滚动加载、`/eval` 填表提交——像人一样在页面内自然导航
-- **读**：用 `/eval` 提取文字内容，判断图片/视频是否承载核心信息——是则提取媒体 URL 定向读取或 `/screenshot` 视觉识别
-
-浏览网页时，**先了解页面结构，再决定下一步动作**。不需要提前规划所有步骤。
-
-### 程序化操作与 GUI 交互
-
-浏览器内操作页面有两种方式：
-
-- **程序化方式**（构造 URL 直接导航、eval 操作 DOM）：成功时速度快、精确，但对网站来说不是正常用户行为，可能触发反爬机制。
-- **GUI 交互**（点击按钮、填写输入框、滚动浏览）：GUI 是为人设计的，网站不会限制正常的 UI 操作，确定性最高，但步骤多、速度慢。
-
-根据对目标平台的了解来灵活选择方式。GUI 交互也是程序化方式的有效探测——通过一次真实交互观察站点的实际行为（URL 模式、必需参数、页面跳转逻辑），为后续程序化操作提供依据；同时当程序化方式受阻时，GUI 交互是可靠的兜底。
-
-**站点内交互产生的链接是可靠的**：通过用户视角中的可交互单元（卡片、条目、按钮）进行的站点内交互，自然到达的 URL 天然携带平台所需的完整上下文。而手动构造的 URL 可能缺失隐式必要参数，导致被拦截、返回错误页面、甚至触发反爬。
-
-## 浏览器 CDP 模式
-
-通过 CDP Proxy 直连用户日常 Chrome，天然携带登录态，无需启动独立浏览器。
-若无用户明确要求，不主动操作用户已有 tab，所有操作都在自己创建的后台 tab 中进行，保持对用户环境的最小侵入。不关闭用户 tab 的前提下，完成任务后关闭自己创建的 tab，保持环境整洁。
-
-### 启动
+Before any real-browser task, run:
 
 ```bash
-node "$CLAUDE_SKILL_DIR/scripts/check-deps.mjs"
+node ~/.codex/skills/web-access/scripts/check-deps.mjs
 ```
 
-脚本会依次检查 Node.js、Chrome 端口，并确保 Proxy 已连接（未运行则自动启动并等待）。Proxy 启动后持续运行。
+Use the script output as the source of truth.
 
-### Proxy API
+- If it prints `proxy: ready`, proceed with CDP calls.
+- If it says Chrome is not connected, fix Chrome remote debugging first.
+- If it says the proxy is connecting, wait for it to report ready before issuing browser actions.
 
-所有操作通过 curl 调用 HTTP API：
+Keep using the user's real Chrome instance whenever possible so existing login state remains available.
+
+## Automation risk notice
+
+Before automating social or authenticated platforms, state this warning plainly:
+
+`Some sites detect browser automation aggressively. Account restrictions are still possible even with safeguards. Continuing means accepting that risk.`
+
+## Tool routing in Codex
+
+Choose the lightest tool that can reliably reach the goal.
+
+| Situation | Use |
+|---|---|
+| Public discovery, current information, search result exploration | Codex `web` search/open |
+| Known URL, mostly static page, raw HTML or JSON-LD needed | shell `curl` |
+| Article-like pages where markdown conversion saves tokens | Jina or other text reduction layer if helpful |
+| Dynamic rendering, anti-bot barriers, login state, uploads, real clicks, scrolling, screenshots | local CDP proxy |
+
+Do not default to CDP when simpler tools can prove the answer.
+Do not stay on static tools after repeated failure against a dynamic or protected site.
+
+## Browser philosophy
+
+Operate toward the goal, not toward a fixed script.
+
+1. Define success first.
+2. Pick the shortest path that can actually reach the content.
+3. Use every page result as evidence.
+4. Change approach quickly when the current route is blocked.
+5. Stop once the task is actually complete.
+
+Treat the browser as a real environment, not as a screenshot machine.
+
+## Recommended Codex workflow
+
+### 1. Check for site-specific knowledge
+
+Before doing CDP work for a known site, try to match existing site patterns:
 
 ```bash
-# 列出用户已打开的 tab
-curl -s http://localhost:3456/targets
-
-# 创建新后台 tab（自动等待加载）
-curl -s "http://localhost:3456/new?url=https://example.com"
-
-# 页面信息
-curl -s "http://localhost:3456/info?target=ID"
-
-# 执行任意 JS：可读写 DOM、提取数据、操控元素、触发状态变更、提交表单、调用内部方法
-curl -s -X POST "http://localhost:3456/eval?target=ID" -d 'document.title'
-
-# 捕获页面渲染状态（含视频当前帧）
-curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"
-
-# 导航、后退
-curl -s "http://localhost:3456/navigate?target=ID&url=URL"
-curl -s "http://localhost:3456/back?target=ID"
-
-# 点击（POST body 为 CSS 选择器）— JS el.click()，简单快速，覆盖大多数场景
-curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'
-
-# 真实鼠标点击 — CDP Input.dispatchMouseEvent，算用户手势，能触发文件对话框
-curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
-
-# 文件上传 — 直接设置 file input 的本地文件路径，绕过文件对话框
-curl -s -X POST "http://localhost:3456/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'
-
-# 滚动（触发懒加载）
-curl -s "http://localhost:3456/scroll?target=ID&y=3000"
-curl -s "http://localhost:3456/scroll?target=ID&direction=bottom"
-
-# 关闭 tab
-curl -s "http://localhost:3456/close?target=ID"
+node ~/.codex/skills/web-access/scripts/match-site.mjs "<task or domain>"
 ```
 
-### 页面内导航
+To list recorded site patterns:
 
-两种方式打开页面内的链接：
+```bash
+node ~/.codex/skills/web-access/scripts/list-site-patterns.mjs
+```
 
-- **`/click`**：在当前 tab 内直接点击用户视角中的可交互单元，简单直接，串行处理。适合需要在同一页面内连续操作的场景，如点击展开、翻页、进入详情等。
-- **`/new` + 完整 URL**：使用目标链接的完整地址（包含所有URL参数），在新 tab 中打开。适合需要同时访问多个页面的场景。
+If a matching pattern exists, read it before browsing.
 
-很多网站的链接包含会话相关的参数（如 token），这些参数是正常访问所必需的。提取 URL 时应保留完整地址，不要裁剪或省略参数。
+### 2. Use Codex web tools first when they are sufficient
 
-### 媒体资源提取
+For public pages:
 
-判断内容在图片里时，用 `/eval` 从 DOM 直接拿图片 URL，再定向读取——比全页截图精准得多。
+- use Codex web search/open for discovery and verification
+- prefer first-party sources over summaries
+- move to `curl` when raw HTML or structured metadata matters
 
-### 技术事实
-- 页面中存在大量已加载但未展示的内容——轮播中非当前帧的图片、折叠区块的文字、懒加载占位元素等，它们存在于 DOM 中但对用户不可见。以数据结构（容器、属性、节点关系）为单位思考，可以直接触达这些内容。
-- DOM 中存在选择器不可跨越的边界（Shadow DOM 的 `shadowRoot`、iframe 的 `contentDocument`等）。eval 递归遍历可一次穿透所有层级，返回带标签的结构化内容，适合快速了解未知页面的完整结构。
-- `/scroll` 到底部会触发懒加载，使未进入视口的图片完成加载。提取图片 URL 前若未滚动，部分图片可能尚未加载。
-- 拿到媒体资源 URL 后，公开资源可直接下载到本地后用读取；需要登录态才可获取的资源才需要在浏览器内 navigate + screenshot。
-- 短时间内密集打开大量页面（如批量 `/new`）可能触发网站的反爬风控。
-- 平台返回的"内容不存在""页面不见了"等提示不一定反映真实状态，也可能是访问方式的问题（如 URL 缺失必要参数、触发反爬）而非内容本身的问题。
+### 3. Enter CDP mode only when needed
 
-### 视频内容获取
+Once CDP is required, interact with the proxy at `http://127.0.0.1:3456`.
 
-用户 Chrome 真实渲染，截图可捕获当前视频帧。核心能力：通过 `/eval` 操控 `<video>` 元素（获取时长、seek 到任意时间点、播放/暂停/全屏），配合 `/screenshot` 采帧，可对视频内容进行离散采样分析。
+Common flow:
 
-### 登录判断
+```bash
+curl -s "http://127.0.0.1:3456/targets"
+curl -s "http://127.0.0.1:3456/new?url=https://example.com"
+curl -s -X POST "http://127.0.0.1:3456/eval?target=ID" -d "document.title"
+curl -s "http://127.0.0.1:3456/close?target=ID"
+```
 
-用户日常 Chrome 天然携带登录态，大多数常用网站已登录。
+Read [references/cdp-api.md](./references/cdp-api.md) when you need endpoint details or extraction patterns.
 
-登录判断的核心问题只有一个：**目标内容拿到了吗？**
+## CDP operating rules
 
-打开页面后先尝试获取目标内容。只有当确认**目标内容无法获取**且判断登录能解决时，才告知用户：
-> "当前页面在未登录状态下无法获取[具体内容]，请在你的 Chrome 中登录 [网站名]，完成后告诉我继续。"
+- Create your own background tab with `/new`; do not hijack existing user tabs unless the user explicitly asks.
+- Use `/eval` as the main way to inspect DOM state, extract structured data, and perform targeted interactions.
+- Use `/click` for straightforward DOM clicks.
+- Use `/clickAt` when the page needs a real mouse gesture.
+- Use `/setFiles` for file uploads.
+- Use `/scroll` to trigger lazy loading before extracting image or media URLs.
+- Use `/screenshot` when visual confirmation is genuinely necessary.
+- Close only the tabs you created.
+- Leave the proxy running after the task; avoid forcing the user to re-authorize Chrome.
 
-登录完成后无需重启任何东西，直接刷新页面继续。
+## Login judgment
 
-### 任务结束
+Do not ask for login preemptively.
 
-用 `/close` 关闭自己创建的 tab，必须保留用户原有的 tab 不受影响。
+1. Open the page.
+2. Try to obtain the target content.
+3. Only if the target content is unavailable and login would likely unblock it, ask the user to log in within Chrome.
+4. After login, refresh and continue. Do not restart the proxy.
 
-Proxy 持续运行，不建议主动停止——重启后需要在 Chrome 中重新授权 CDP 连接。
+Phrase the login request concretely, for example:
 
-## 并行调研：子 Agent 分治策略
+`The target content is not accessible without login on <site>. Please log in in your Chrome window, then I will continue.`
 
-任务包含多个**独立**调研目标时（如同时调研 N 个项目、N 个来源），鼓励合理分治给子 Agent 并行执行，而非主 Agent 串行处理。
+## Media extraction
 
-**好处：**
-- **速度**：多子 Agent 并行，总耗时约等于单个子任务时长
-- **上下文保护**：抓取内容不进入主 Agent 上下文，主 Agent 只接收摘要，节省 token
+Prefer direct DOM extraction over screenshots.
 
-**并行 CDP 操作**：每个子 Agent 在当前用户浏览器实例中，自行创建所需的后台 tab（`/new`），自行操作，任务结束自行关闭（`/close`）。所有子 Agent 共享一个 Chrome、一个 Proxy，通过不同 targetId 操作不同 tab，无竞态风险。
+- For images: extract `src`, `srcset`, or linked asset URLs through `/eval`.
+- For videos: inspect the `<video>` element, jump to timestamps with `/eval`, then use `/screenshot` for frame capture when needed.
+- Use full-page screenshots only when the content truly lives in layout or styling rather than in accessible DOM/media URLs.
 
-**子 Agent Prompt 写法：目标导向，而非步骤指令**
-- 必须在子 Agent prompt 中写 `必须加载 web-access skill 并遵循指引` ，子 Agent 会自动加载 skill，无需在 prompt 中复制 skill 内容或指定路径。
-- 子 Agent 有自主判断能力。主 Agent 的职责是说清楚**要什么**，仅在必要与确信时限定**怎么做**。过度指定步骤会剥夺子 Agent 的判断空间，反而引入主 Agent 的假设错误。**避免 prompt 用词对子 Agent 行为的暗示**：「搜索xx」会把子 Agent 锚定到 WebSearch，而实际上有些反爬站点需要 CDP 直接访问主站才能有效获取内容。主 Agent 写 prompt 时应描述目标（「获取」「调研」「了解」），避免用暗示具体手段的动词（「搜索」「抓取」「爬取」）。
+## Parallel research in Codex
 
-**分治判断标准：**
+Use sub-agents only when the user explicitly asks for delegation or parallel work.
 
-| 适合分治 | 不适合分治 |
-|----------|-----------|
-| 目标相互独立，结果互不依赖 | 目标有依赖关系，下一个需要上一个的结果 |
-| 每个子任务量足够大（多页抓取、多轮搜索） | 简单单页查询，分治开销大于收益 |
-| 需要 CDP 浏览器或长时间运行的任务 | 几次 WebSearch / Jina 就能完成的轻量查询 |
+When parallelization is allowed:
 
-## 信息核实类任务
+- split only independent targets
+- tell each sub-agent to use `$web-access`
+- describe the goal, not the exact tool sequence
+- let each sub-agent create and close its own tab through the shared proxy
 
-核实的目标是**一手来源**，而非更多的二手报道。多个媒体引用同一个错误会造成循环印证假象。
+Good delegation wording:
 
-搜索引擎和聚合平台是信息发现入口，是**定位**信息的工具，不可用于直接**证明**真伪。找到来源后，直接访问读取原文。同一原则适用于工具能力/用法的调研——官方文档是一手来源，不确定时先查文档或源码，不猜测。
+`Use $web-access to investigate this site and return the key findings plus source URLs.`
 
-| 信息类型 | 一手来源 |
-|----------|---------|
-| 政策/法规 | 发布机构官网 |
-| 企业公告 | 公司官方新闻页 |
-| 学术声明 | 原始论文/机构官网 |
-| 工具能力/用法 | 官方文档、源码 |
+Avoid wording that over-constrains the method, such as "search X with tool Y first", unless the method is itself the point of the task.
 
-**找不到官网时**：权威媒体的原创报道（非转载）可作为次级依据，但需向用户说明："未找到官方原文，以下核实来自[媒体名]报道，存在转述误差可能。"单一来源时同样向用户声明。
+## Site-pattern maintenance
 
-## 站点经验
+Store durable, verified site knowledge in `references/site-patterns/<domain>.md`.
+Write facts, not guesses.
 
-操作中积累的特定网站经验，按域名存储在 `references/site-patterns/` 下。
+Use this format:
 
-已有经验的站点：!`node -e "const fs=require('fs'),p=require('path').join(process.env.CLAUDE_SKILL_DIR||'.','references','site-patterns');try{console.log(fs.readdirSync(p).filter(f=>f.endsWith('.md')).map(f=>f.replace(/\\.md$/,'')).join(', ')||'暂无')}catch{console.log('暂无')}"`
-
-确定目标网站后，如果上方列表中有匹配的站点，必须读取对应文件获取先验知识（平台特征、有效模式、已知陷阱）。经验内容标注了发现日期，当作可能有效的提示而非保证——如果按经验操作失败，回退通用模式并更新经验文件。
-
-CDP 操作成功完成后，如果发现了有必要记录经验的新站点或新模式（URL 结构、平台特征、操作策略），主动写入对应的站点经验文件。只写经过验证的事实，不写未确认的猜测。
-
-文件格式：
 ```markdown
 ---
 domain: example.com
-aliases: [示例, Example]
-updated: 2026-03-19
+aliases: [Example]
+updated: 2026-04-05
 ---
-## 平台特征
-架构、反爬行为、登录需求、内容加载方式等事实
 
-## 有效模式
-已验证的 URL 模式、操作策略、选择器
+## Platform traits
+Verified facts about rendering, login, anti-bot behavior, and navigation.
 
-## 已知陷阱
-什么会失败以及为什么
+## Effective patterns
+Verified URL patterns, selectors, and working interaction strategies.
+
+## Known traps
+Verified failure modes and why they fail.
 ```
-经验/陷阱内容标注发现日期，当作"可能有效的提示"而非"保证正确的事实"。
 
-## References 索引
+After a successful browser session that revealed reusable facts, update the relevant site-pattern file.
 
-| 文件 | 何时加载 |
-|------|---------|
-| `references/cdp-api.md` | 需要 CDP API 详细参考、JS 提取模式、错误处理时 |
-| `references/site-patterns/{domain}.md` | 确定目标网站后，读取对应站点经验 |
+## Verification standard
+
+Do not claim completion without evidence.
+
+Validate with one or more of:
+
+- proxy JSON output
+- extracted DOM values
+- navigation state from `/info`
+- screenshots when necessary
+- first-party source pages opened through Codex web tools
+
+## References
+
+- [references/cdp-api.md](./references/cdp-api.md): detailed CDP endpoints and examples
+- `references/site-patterns/<domain>.md`: domain-specific knowledge
+- [scripts/check-deps.mjs](./scripts/check-deps.mjs): environment check and proxy readiness
+- [scripts/cdp-proxy.mjs](./scripts/cdp-proxy.mjs): local CDP proxy
+- [scripts/match-site.mjs](./scripts/match-site.mjs): site-pattern matcher
+- [scripts/list-site-patterns.mjs](./scripts/list-site-patterns.mjs): site-pattern inventory

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Web Access"
+  short_description: "Research dynamic and authenticated sites"
+  default_prompt: "Use $web-access to research a dynamic or authenticated website with Codex-native web and CDP workflows."

--- a/references/cdp-api.md
+++ b/references/cdp-api.md
@@ -1,106 +1,117 @@
-# CDP Proxy API 参考
+# CDP Proxy API
 
-## 基础信息
+## Basics
 
-- 地址：`http://localhost:3456`
-- 启动：`node ~/.claude/skills/web-access/scripts/cdp-proxy.mjs &`
-- 启动后持续运行，不建议主动停止（重启需 Chrome 重新授权）
-- 强制停止：`pkill -f cdp-proxy.mjs`
+- proxy base URL: `http://127.0.0.1:3456`
+- start check: `node ~/.codex/skills/web-access/scripts/check-deps.mjs`
+- direct proxy start: `node ~/.codex/skills/web-access/scripts/cdp-proxy.mjs`
+- the proxy auto-discovers Chrome's debugging port and prefers the full `webSocketDebuggerUrl` from `/json/version`
 
-## API 端点
+## Endpoints
 
-### GET /health
-健康检查，返回连接状态。
+### Health
+
 ```bash
-curl -s http://localhost:3456/health
+curl -s http://127.0.0.1:3456/health
 ```
 
-### GET /targets
-列出所有已打开的页面 tab。返回数组，每项含 `targetId`、`title`、`url`。
+Returns proxy health, connection state, and detected Chrome port.
+
+### List tabs
+
 ```bash
-curl -s http://localhost:3456/targets
+curl -s http://127.0.0.1:3456/targets
 ```
 
-### GET /new?url=URL
-创建新后台 tab，自动等待页面加载完成。返回 `{ targetId }`.
+### Create a background tab
+
 ```bash
-curl -s "http://localhost:3456/new?url=https://example.com"
+curl -s "http://127.0.0.1:3456/new?url=https://example.com"
 ```
 
-### GET /close?target=ID
-关闭指定 tab。
+### Close a tab
+
 ```bash
-curl -s "http://localhost:3456/close?target=TARGET_ID"
+curl -s "http://127.0.0.1:3456/close?target=TARGET_ID"
 ```
 
-### GET /navigate?target=ID&url=URL
-在已有 tab 中导航到新 URL，自动等待加载。
+### Navigate
+
 ```bash
-curl -s "http://localhost:3456/navigate?target=ID&url=https://example.com"
+curl -s "http://127.0.0.1:3456/navigate?target=TARGET_ID&url=https://example.com"
 ```
 
-### GET /back?target=ID
-后退一页。
+### Go back
+
 ```bash
-curl -s "http://localhost:3456/back?target=ID"
+curl -s "http://127.0.0.1:3456/back?target=TARGET_ID"
 ```
 
-### GET /info?target=ID
-获取页面基础信息（title、url、readyState）。
+### Page info
+
 ```bash
-curl -s "http://localhost:3456/info?target=ID"
+curl -s "http://127.0.0.1:3456/info?target=TARGET_ID"
 ```
 
-### POST /eval?target=ID
-执行 JavaScript 表达式，POST body 为 JS 代码。
+### Evaluate JavaScript
+
 ```bash
-curl -s -X POST "http://localhost:3456/eval?target=ID" -d 'document.title'
+curl -s -X POST "http://127.0.0.1:3456/eval?target=TARGET_ID" -d "document.title"
 ```
 
-### POST /click?target=ID
-JS 层面点击（`el.click()`），POST body 为 CSS 选择器。自动 scrollIntoView 后点击。简单快速，覆盖大多数场景。
+Use `/eval` to:
+
+- inspect DOM state
+- extract structured values
+- control `<video>` elements
+- trigger page-side interactions that are easier in JavaScript than raw CDP events
+
+### DOM click
+
 ```bash
-curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'
+curl -s -X POST "http://127.0.0.1:3456/click?target=TARGET_ID" -d "button.submit"
 ```
 
-### POST /clickAt?target=ID
-CDP 浏览器级真实鼠标点击（`Input.dispatchMouseEvent`），POST body 为 CSS 选择器。先获取元素坐标，再模拟鼠标按下/释放。算真实用户手势，能触发文件对话框、绕过部分反自动化检测。
+### Real mouse click
+
 ```bash
-curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
+curl -s -X POST "http://127.0.0.1:3456/clickAt?target=TARGET_ID" -d "button.upload"
 ```
 
-### POST /setFiles?target=ID
-给 file input 设置本地文件路径（`DOM.setFileInputFiles`），完全绕过文件对话框。POST body 为 JSON。
+Use `/clickAt` when the page requires a real mouse gesture or a file-picker trigger.
+
+### Upload files
+
 ```bash
-curl -s -X POST "http://localhost:3456/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file1.png","/path/to/file2.png"]}'
+curl -s -X POST "http://127.0.0.1:3456/setFiles?target=TARGET_ID" \
+  -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'
 ```
 
-### GET /scroll?target=ID&y=3000&direction=down
-滚动页面。`direction` 可选 `down`（默认）、`up`、`top`、`bottom`。滚动后自动等待 800ms 供懒加载触发。
+### Scroll
+
 ```bash
-curl -s "http://localhost:3456/scroll?target=ID&y=3000"
-curl -s "http://localhost:3456/scroll?target=ID&direction=bottom"
+curl -s "http://127.0.0.1:3456/scroll?target=TARGET_ID&y=3000"
+curl -s "http://127.0.0.1:3456/scroll?target=TARGET_ID&direction=bottom"
 ```
 
-### GET /screenshot?target=ID&file=/tmp/shot.png
-截图。指定 `file` 参数保存到本地文件；不指定则返回图片二进制。可选 `format=jpeg`。
+### Screenshot
+
 ```bash
-curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"
+curl -s "http://127.0.0.1:3456/screenshot?target=TARGET_ID&file=/tmp/shot.png"
 ```
 
-## /eval 使用提示
+## Extraction guidance
 
-- POST body 为任意 JS 表达式，返回 `{ value }` 或 `{ error }`
-- 支持 `awaitPromise`：可以写 async 表达式
-- 返回值必须是可序列化的（字符串、数字、对象），DOM 节点不能直接返回，需要提取属性
-- 提取大量数据时用 `JSON.stringify()` 包裹，确保返回字符串
-- 根据页面实际 DOM 结构编写选择器，不要套用固定模板
+- Return serializable values from `/eval`; do not try to return raw DOM nodes.
+- Use `JSON.stringify(...)` when returning larger nested data structures.
+- Prefer extracting media URLs from DOM attributes before falling back to screenshots.
+- Re-check the DOM after scrolling when lazy loading is involved.
 
-## 错误处理
+## Common errors
 
-| 错误 | 原因 | 解决 |
-|------|------|------|
-| `Chrome 未开启远程调试端口` | Chrome 未开启远程调试 | 提示用户打开 `chrome://inspect/#remote-debugging` 并勾选 Allow |
-| `attach 失败` | targetId 无效或 tab 已关闭 | 用 `/targets` 获取最新列表 |
-| `CDP 命令超时` | 页面长时间未响应 | 重试或检查 tab 状态 |
-| `端口已被占用` | 另一个 proxy 已在运行 | 已有实例可直接复用 |
+| Error | Meaning | Action |
+|---|---|---|
+| `Chrome not connected` | Chrome debugging is unavailable | Run `check-deps.mjs` and fix Chrome debugging first |
+| `attach failed` | target ID is stale or closed | Refresh `/targets` and retry |
+| `CDP command timeout` | page is blocked or unresponsive | retry, inspect DOM state, or reduce the page action |
+| proxy starts but fails to connect | Chrome port exists but the websocket path changed | ensure `/json/version` is reachable and restart the proxy |

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -101,8 +101,23 @@ function checkPort(port) {
   });
 }
 
-function getWebSocketUrl(port, wsPath) {
+async function getWebSocketUrl(port, wsPath) {
   if (wsPath) return `ws://127.0.0.1:${port}${wsPath}`;
+
+  try {
+    const resp = await fetch(`http://127.0.0.1:${port}/json/version`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data?.webSocketDebuggerUrl) {
+        return data.webSocketDebuggerUrl;
+      }
+    }
+  } catch {
+    // Fall back to the legacy path when /json/version is unavailable.
+  }
+
   return `ws://127.0.0.1:${port}/devtools/browser`;
 }
 
@@ -129,7 +144,7 @@ async function connect() {
     chromeWsPath = discovered.wsPath;
   }
 
-  const wsUrl = getWebSocketUrl(chromePort, chromeWsPath);
+  const wsUrl = await getWebSocketUrl(chromePort, chromeWsPath);
   if (!wsUrl) throw new Error('无法获取 Chrome WebSocket URL');
 
   return connectingPromise = new Promise((resolve, reject) => {

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -8,8 +8,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+// Codex CLI adaptation: resolve the skill root dynamically.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
 const PROXY_SCRIPT = path.join(ROOT, 'scripts', 'cdp-proxy.mjs');
+console.log('Codex web-access skill root:', ROOT);
+console.log('CDP proxy script:', PROXY_SCRIPT);
 const PROXY_PORT = Number(process.env.CDP_PROXY_PORT || 3456);
 
 // --- Node.js 版本检查 ---

--- a/scripts/list-site-patterns.mjs
+++ b/scripts/list-site-patterns.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '..');
+const patternsDir = path.join(root, 'references', 'site-patterns');
+
+if (!fs.existsSync(patternsDir)) {
+  process.stdout.write('none\n');
+  process.exit(0);
+}
+
+const names = fs
+  .readdirSync(patternsDir, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+  .map((entry) => entry.name.replace(/\.md$/, ''))
+  .sort((a, b) => a.localeCompare(b));
+
+process.stdout.write(`${names.join('\n') || 'none'}\n`);


### PR DESCRIPTION
## Summary
- add a Codex-native `SKILL.md` and `agents/openai.yaml`
- document Codex routing between web tools, curl, and the local CDP proxy
- add `scripts/list-site-patterns.mjs` for site-pattern inventory
- fix CDP websocket discovery by reading `/json/version` when Chrome does not expose a stable legacy websocket path
- update README and CDP API reference for Codex usage

## Validation
- `python -X utf8 C:\Users\Seven\.codex\skills\.system\skill-creator\scripts\quick_validate.py C:\Users\Seven\.codex\skills\web-access-upstream`
- `node --check scripts/check-deps.mjs`
- `node --check scripts/cdp-proxy.mjs`
- `node --check scripts/match-site.mjs`
- `node --check scripts/list-site-patterns.mjs`