### PR TITLE
feat: add Edge support + dynamic CDP port discovery via process scanning

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -56,6 +56,7 @@ async function discoverChromePort() {
     possiblePaths.push(
       path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
       path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
+      path.join(localAppData, 'Microsoft/Edge/User Data/DevToolsActivePort'),
     );
   }
 
@@ -86,6 +87,40 @@ async function discoverChromePort() {
       return { port, wsPath: null };
     }
   }
+  // 3. 通过进程扫描找到浏览器动态 CDP 端口
+  try {
+    const { execSync } = await import('node:child_process');
+    const out = execSync(
+      platform === 'win32'
+        ? 'netstat -ano | findstr "LISTENING"'
+        : 'ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null',
+      { encoding: 'utf8', timeout: 5000 }
+    );
+    let browserPids = new Set();
+    try {
+      const psOut = execSync(
+        platform === 'win32'
+          ? 'tasklist /FI "IMAGENAME eq msedge.exe" /FO CSV /NH & tasklist /FI "IMAGENAME eq chrome.exe" /FO CSV /NH'
+          : 'pgrep -f "chrome|msedge|chromium"',
+        { encoding: 'utf8', timeout: 5000 }
+      );
+      browserPids = new Set(
+        psOut.split('\n').map(l => { const m = l.match(/(\d+)/); return m ? parseInt(m[1]) : null; }).filter(Boolean)
+      );
+    } catch {}
+    for (const line of out.split('\n').filter(Boolean)) {
+      const m = line.match(/:(\d+)\s.*LISTENING\s+(\d+)/);
+      if (!m) continue;
+      const p = parseInt(m[1]), pid = parseInt(m[2]);
+      if (!browserPids.has(pid)) continue;
+      if (p < 1024 || p >= 65536) continue;
+      if (!(await checkPort(p))) continue;
+      try {
+        const r = await fetch(`http://127.0.0.1:${p}/json/version`, { signal: AbortSignal.timeout(1000) });
+        if (r.ok) { console.log(`[CDP Proxy] 进程扫描发现调试端口: ${p}`); return { port: p, wsPath: null }; }
+      } catch {}
+    }
+  } catch {}
 
   return null;
 }

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -56,6 +56,7 @@ function activePortFiles() {
       return [
         path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
         path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
+        path.join(localAppData, 'Microsoft/Edge/User Data/DevToolsActivePort'),
       ];
     default:
       return [];
@@ -73,12 +74,59 @@ async function detectChromePort() {
       }
     } catch (_) {}
   }
-  // 回退：探测常见端口
-  for (const port of [9222, 9229, 9333]) {
-    if (await checkPort(port)) {
-      return port;
-    }
+  // 回退：探测常见端口（固定 + 动态范围）
+  const commonPorts = [9222, 9229, 9333];
+  for (const port of commonPorts) {
+    if (await checkPort(port)) return port;
   }
+  // 扫描动态端口范围（Chrome/Edge 远程调试通常分配在 1900-9999）
+  // 只扫已知的 Edge/Chrome 进程占用的端口，避免全段扫描
+  try {
+    const { execSync } = await import('node:child_process');
+    const out = execSync(
+      os.platform() === 'win32'
+        ? 'netstat -ano | findstr "LISTENING"'
+        : 'ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null',
+      { encoding: 'utf8', timeout: 5000 }
+    );
+    const lines = out.split('\n').filter(Boolean);
+    // 匹配 chrome/msedge/chromium 进程的监听端口
+    const browserPorts = lines
+      .map(line => {
+        const m = line.match(/:(\d+)\s.*LISTENING\s+(\d+)/);
+        return m ? { port: parseInt(m[1]), pid: parseInt(m[2]) } : null;
+      })
+      .filter(Boolean);
+    // 获取浏览器进程 PID 集合
+    let browserPids = new Set();
+    try {
+      const psOut = execSync(
+        os.platform() === 'win32'
+          ? 'tasklist /FI "IMAGENAME eq msedge.exe" /FO CSV /NH & tasklist /FI "IMAGENAME eq chrome.exe" /FO CSV /NH'
+          : 'pgrep -f "chrome|msedge|chromium"',
+        { encoding: 'utf8', timeout: 5000 }
+      );
+      browserPids = new Set(
+        psOut.split('\n')
+          .map(l => {
+            const m = l.match(/(\d+)/);
+            return m ? parseInt(m[1]) : null;
+          })
+          .filter(Boolean)
+      );
+    } catch { /* pid detection failed */ }
+    // 从浏览器进程的监听端口中找 CDP 端口
+    for (const { port, pid } of browserPorts) {
+      if (!browserPids.has(pid)) continue;
+      if (port >= 1024 && port < 65536 && await checkPort(port)) {
+        // 验证是否是 CDP 端点（返回 JSON）
+        try {
+          const resp = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(1000) });
+          if (resp.ok) return port;
+        } catch { /* not CDP */ }
+      }
+    }
+  } catch { /* process scan failed, skip */ }
   return null;
 }
 


### PR DESCRIPTION
- Add Microsoft Edge DevToolsActivePort path for Windows users
- Add process-scanning fallback: finds Chrome/Edge CDP port by intersecting netstat listening ports with browser process PIDs, then verifying each candidate via /json/version endpoint
- Works when remote debugging port is dynamically assigned (e.g. via chrome://inspect/#remote-debugging)
- Cross-platform: Windows (netstat+tasklist), Linux/macOS (ss/pgrep)