### PR TITLE
docs: 补充目标 URL 未知时优先查本地 Chrome 书签/历史

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -68,6 +68,19 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 
 浏览网页时，**先了解页面结构，再决定下一步动作**。不需要提前规划所有步骤。
 
+### 目标 URL 未知时
+
+用户提到的系统若带有组织内部特征（如"我们的 XX 系统"、"公司 XX 平台"），或公网搜索无实质命中，优先查用户本地 Chrome 书签/历史——内网系统、SSO 后台、组织内部工具不会出现在公网搜索结果中，但通常已在用户的书签里。
+
+- **书签文件**：Chrome 用户数据目录下的 `Bookmarks`（JSON，grep 关键词即可）
+  - macOS：`~/Library/Application Support/Google/Chrome/Default/Bookmarks`
+  - Linux：`~/.config/google-chrome/Default/Bookmarks`
+  - Windows：`%LOCALAPPDATA%\Google\Chrome\User Data\Default\Bookmarks`
+- **历史数据库**：同目录下的 `History`（SQLite，可用 `sqlite3` 查询）
+- 多 profile 用户的 profile 名可查父目录下的 `Local State`（`profile.info_cache` 字段）
+
+查到 URL 后再决定用 WebFetch / curl / CDP。本地一手线索优先于向用户索要 URL。
+
 ### 程序化操作与 GUI 交互
 
 浏览器内操作页面有两种方式：


### PR DESCRIPTION
## 背景

在实际使用中遇到一个典型场景：用户让 agent 操作内部系统（如"财务小智"这类组织内部产品名），WebSearch 公网搜不到（内网 IP / SSO 后台），agent 就会直接问用户要 URL——但用户 Chrome 书签里其实早就有。浪费一轮交互，且没用上本地的一手信息。

## 改动

在 \`## 联网工具选择\` 下新增 \`### 目标 URL 未知时\` 子节，说明：

- 识别场景：用户提到带组织内部特征的系统，或公网搜索无实质命中
- 优先查本地 Chrome \`Bookmarks\`（JSON）和 \`History\`（SQLite）
- 给出 macOS / Linux / Windows 三平台路径
- 多 profile 场景可查 \`Local State\` 的 \`profile.info_cache\`

## 为什么放在"联网工具选择"下

选择联网工具的前提是知道目标 URL。当 URL 未知时，先解决"入口定位"再决定用 WebFetch / curl / CDP，逻辑上先于既有的 \`### 程序化操作与 GUI 交互\`，因此放在其前面。

## 验证

本地将修改应用到激活 skill 后，用两个全新 session 的子 agent 测试（均为只输出行动计划、不实际执行）：

1. "查一下财务小智上目前在途的流程有哪些"
2. "深地数字化管理平台查看一下目前活跃的任务"

两次测试结果一致：子 agent 的第一个动作都是 grep 本地 Chrome 书签文件，把询问用户索要 URL 放到最后兜底，并明确引用了新增子节作为依据。对照组（未应用改动时）则是直接问用户要 URL。

同时用该场景跑了一个真实任务（打开"财务小智"查在途报销），URL 从本地书签一次命中，流程顺畅。

## 不改的部分

- 未动版本号、README、changelog —— 留给维护者决定是否采纳及如何发布