### PR TITLE
feat: auto-cleanup idle tabs created by proxy

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -15,6 +15,9 @@ let ws = null;
 let cmdId = 0;
 const pending = new Map(); // id -> {resolve, timer}
 const sessions = new Map(); // targetId -> sessionId
+const managedTabs = new Map(); // targetId -> { lastAccessed: number }
+const TAB_IDLE_TIMEOUT = parseInt(process.env.CDP_TAB_IDLE_TIMEOUT || '300000'); // 5 min default
+const CLEANUP_INTERVAL = 60000; // sweep every 60s
 
 // --- WebSocket 兼容层 ---
 let WS;
@@ -157,6 +160,7 @@ async function connect() {
       chromePort = null; // 重置端口缓存，下次连接重新发现
       chromeWsPath = null;
       sessions.clear();
+      managedTabs.clear();
     };
     const onMessage = (evt) => {
       const data = typeof evt === 'string' ? evt : (evt.data || evt);
@@ -247,6 +251,35 @@ async function enablePortGuard(sessionId) {
   } catch { /* Fetch 域启用失败不影响主流程 */ }
 }
 
+// --- 闲置 Tab 自动清理 ---
+function touchTab(targetId) {
+  const entry = managedTabs.get(targetId);
+  if (entry) entry.lastAccessed = Date.now();
+}
+
+async function cleanupIdleTabs() {
+  if (!ws || (ws.readyState !== WS.OPEN && ws.readyState !== 1)) return;
+  const now = Date.now();
+  for (const [targetId, info] of managedTabs) {
+    if (now - info.lastAccessed < TAB_IDLE_TIMEOUT) continue;
+    try { await sendCDP('Target.closeTarget', { targetId }); } catch { /* tab may already be closed */ }
+    sessions.delete(targetId);
+    managedTabs.delete(targetId);
+    console.log(`[CDP Proxy] Auto-closed idle tab: ${targetId}`);
+  }
+}
+
+async function closeAllManagedTabs() {
+  if (!ws || (ws.readyState !== WS.OPEN && ws.readyState !== 1)) return;
+  const targets = [...managedTabs.keys()];
+  for (const targetId of targets) {
+    try { await sendCDP('Target.closeTarget', { targetId }); } catch { /* ignore */ }
+    sessions.delete(targetId);
+    managedTabs.delete(targetId);
+  }
+  if (targets.length) console.log(`[CDP Proxy] Shutdown: closed ${targets.length} managed tab(s)`);
+}
+
 // --- 等待页面加载 ---
 async function waitForLoad(sessionId, timeoutMs = 15000) {
   // 启用 Page 域
@@ -289,6 +322,7 @@ const server = http.createServer(async (req, res) => {
   const parsed = new URL(req.url, `http://localhost:${PORT}`);
   const pathname = parsed.pathname;
   const q = Object.fromEntries(parsed.searchParams);
+  if (q.target) touchTab(q.target);
 
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
 
@@ -296,7 +330,7 @@ const server = http.createServer(async (req, res) => {
     // /health 不需要连接 Chrome
     if (pathname === '/health') {
       const connected = ws && (ws.readyState === WS.OPEN || ws.readyState === 1);
-      res.end(JSON.stringify({ status: 'ok', connected, sessions: sessions.size, chromePort }));
+      res.end(JSON.stringify({ status: 'ok', connected, sessions: sessions.size, managedTabs: managedTabs.size, chromePort }));
       return;
     }
 
@@ -314,6 +348,7 @@ const server = http.createServer(async (req, res) => {
       const targetUrl = q.url || 'about:blank';
       const resp = await sendCDP('Target.createTarget', { url: targetUrl, background: true });
       const targetId = resp.result.targetId;
+      managedTabs.set(targetId, { lastAccessed: Date.now() });
 
       // 等待页面加载
       if (targetUrl !== 'about:blank') {
@@ -330,6 +365,7 @@ const server = http.createServer(async (req, res) => {
     else if (pathname === '/close') {
       const resp = await sendCDP('Target.closeTarget', { targetId: q.target });
       sessions.delete(q.target);
+      managedTabs.delete(q.target);
       res.end(JSON.stringify(resp.result));
     }
 
@@ -588,6 +624,19 @@ async function main() {
     // 启动时尝试连接 Chrome（非阻塞）
     connect().catch(e => console.error('[CDP Proxy] 初始连接失败:', e.message, '（将在首次请求时重试）'));
   });
+
+  // 定时清理闲置 tab
+  const cleanupTimer = setInterval(cleanupIdleTabs, CLEANUP_INTERVAL);
+  cleanupTimer.unref();
+
+  const shutdown = async (sig) => {
+    console.log(`[CDP Proxy] ${sig}, cleaning up...`);
+    clearInterval(cleanupTimer);
+    await closeAllManagedTabs();
+    process.exit(0);
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
 // 防止未捕获异常导致进程崩溃


### PR DESCRIPTION
## Summary

Agents (especially parallel sub-agents) often fail to call `/close` when they crash, run out of context, or exit early — leaving orphan tabs accumulating in the user's browser.

This PR adds automatic idle tab cleanup to `cdp-proxy.mjs`:

- **Track proxy-created tabs** in a `managedTabs` Map — only tabs created via `/new` are tracked; user's own tabs are never touched
- **Auto-close idle tabs** — a 60-second sweep closes any managed tab idle for 5+ minutes (configurable via `CDP_TAB_IDLE_TIMEOUT` env var)
- **Graceful shutdown** — on SIGINT/SIGTERM, all managed tabs are closed before the process exits
- **Centralized activity refresh** — every API call with a `?target=` param automatically refreshes that tab's last-accessed timestamp, so active tabs are never incorrectly cleaned up
- **`/health` reports managed tab count** — useful for debugging

## Changes

- **1 file changed**: `scripts/cdp-proxy.mjs` (+50 lines)
- **0 new files**, **0 new dependencies**
- **API behavior unchanged** — all existing endpoints work exactly as before

## Test plan

All tested locally (Node.js 25.5, macOS, Chrome 9222):

- [x] Start proxy → `/new` to create tab → wait 5+ min without activity → confirm tab auto-closed (log: "Auto-closed idle tab")
- [x] `/new` to create tab → call `/info` every minute → confirm tab stays alive (activity refresh prevents cleanup)
- [x] `/new` to create tab → `/close` it → `/health` shows `managedTabs: 0`
- [x] User's own tabs (not created via `/new`) are never affected by cleanup
- [x] Ctrl+C / SIGTERM the proxy → confirm all managed tabs are closed (log: "Shutdown: closed N managed tab(s)")
- [x] `/health` endpoint returns `managedTabs` count correctly