### PR TITLE
feat(cdp): 新增专用浏览器模式，支持主力浏览器/专用浏览器双模式与任意Chromium 浏览器选择

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ AI Agent 原本的联网能力（WebSearch、WebFetch）缺少调度策略和浏
 | 能力 | 说明 |
 |------|------|
 | 联网工具自动选择 | WebSearch / WebFetch / curl / Jina / CDP，按场景自主判断，可任意组合 |
-| CDP Proxy 浏览器操作 | 直连用户日常 Chrome，天然携带登录态，支持动态页面、交互操作、视频截帧 |
+| CDP Proxy 浏览器操作 | 直连用户日常浏览器，天然携带登录态，支持动态页面、交互操作、视频截帧 |
 | 三种点击方式 | `/click`（JS click）、`/clickAt`（CDP 真实鼠标事件）、`/setFiles`（文件上传） |
-| 本地 Chrome 书签/历史检索 | `find-url.mjs` 查询公网搜不到的目标（内部系统）或用户访问过的页面，支持关键词/时间窗/访问频度排序 |
+| 本地浏览器书签/历史检索（Chrome） | `find-url.mjs` 查询公网搜不到的目标（内部系统）或用户访问过的页面，支持关键词/时间窗/访问频度排序 |
 | 并行分治 | 多目标时分发子 Agent 并行执行，共享一个 Proxy，tab 级隔离 |
 | 站点经验积累 | 按域名存储操作经验（URL 模式、平台特征、已知陷阱），跨 session 复用 |
 | 媒体提取 | 从 DOM 直取图片/视频 URL，或对视频任意时间点截帧分析 |
 
 **v2.5.0 更新：**
-- **本地 Chrome 资源检索** — 新增 `scripts/find-url.mjs`，从本地 Chrome 书签/历史按关键词/时间窗/访问频度定位 URL。典型场景：用户提到组织内部系统（"我们的 XX 平台"等公网搜不到的目标）、回查之前访问过但不记得地址的页面、查看最近高频访问网站等（场景感谢 @MVPGFC 在 #60 提出）
+- **本地浏览器资源检索（Chrome）** — 新增 `scripts/find-url.mjs`，从本地浏览器（Chrome）书签/历史按关键词/时间窗/访问频度定位 URL。典型场景：用户提到组织内部系统（"我们的 XX 平台"等公网搜不到的目标）、回查之前访问过但不记得地址的页面、查看最近高频访问网站等（场景感谢 @MVPGFC 在 #60 提出）
 
 <details><summary>v2.4.3 更新</summary>
 
@@ -103,22 +103,60 @@ git clone https://github.com/eze-is/web-access ~/.claude/skills/web-access
 
 ## 前置配置（CDP 模式）
 
-CDP 模式需要 **Node.js 22+** 和 Chrome 开启远程调试：
+CDP 模式需要 **Node.js 22+** 和浏览器开启远程调试。
 
-1. Chrome 地址栏打开 `chrome://inspect/#remote-debugging`
+先决定用哪种浏览器模式，再进入对应配置：
+
+| 模式 | 适合场景 | 主要优势 | 主要代价 |
+|------|----------|----------|----------|
+| main browser | 需要立刻复用现有登录态，马上执行任务 | 自动继承现有登录态、书签、插件 | 连接时可能需要处理远程调试授权弹窗；Agent 操作和用户自己的浏览器操作不隔离 |
+| 专用浏览器（dedicated） | 追求 autonomous agent 长时间稳定运行，用户不必一直守在电脑旁 | 通常不需要反复确认远程调试授权；Agent 操作和用户日常浏览隔离 | 首次配置需要单独登录常用网站、安装插件、准备 profile |
+
+如果是 Agent 在向用户发起模式选择，不应只给“1 / 2”两个编号。应该把两者的差异、收益和代价直接讲清楚，让用户按自己的场景选择：
+
+- 需要立刻复用现有登录态、马上完成一次任务：通常选 `main browser`
+- 需要把 Agent 操作和日常使用隔离开、希望长期稳定复用同一套环境：通常选 `专用浏览器（dedicated）`
+
+### main browser
+
+1. 在 Chromium 系浏览器地址栏打开 `chrome://inspect/#remote-debugging`
 2. 勾选 **Allow remote debugging for this browser instance**（可能需要重启浏览器）
 
-环境检查（Agent 运行时会自动完成前置检查，无需手动执行）：
+### 专用浏览器（dedicated）
+
+先选定一个稳定的 `browser-id`：
+
+| browser-id | 浏览器 App 名称 |
+|---|---|
+| `chrome` | `Google Chrome` |
+| `chrome-canary` | `Google Chrome Canary` |
+| `chromium` | `Chromium` |
+| `brave` | `Brave Browser` |
+| `edge` | `Microsoft Edge` |
+| `arc` | `Arc` |
+
+对应的专用 profile 目录固定为：`$HOME/.web-access/<browser-id>-dedicated-profile`
+
+macOS 启动命令示例：
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
-# $CLAUDE_SKILL_DIR 是 skill 加载时自动设置的环境变量
-# 手动运行请替换为实际路径，如 ~/.claude/skills/web-access
+open -na "Brave Browser" --args \
+  --remote-debugging-port=9333 \
+  --user-data-dir="$HOME/.web-access/brave-dedicated-profile"
 ```
+
+专用浏览器启动后，可以显式运行 dedicated 检查命令：
+
+```bash
+node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id brave
+# $CLAUDE_SKILL_DIR 是 skill 加载时自动设置的环境变量
+```
+
+默认检查命令 `node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"` 会自动检查 main browser 和专用 profile。已经明确进入专用浏览器路径时，后续检查和连接建议继续带上 `--browser dedicated --browser-id ...`，保持路径一致。
 
 ## CDP Proxy API
 
-Proxy 通过 WebSocket 直连 Chrome（兼容 `chrome://inspect` 方式，无需命令行参数启动），提供 HTTP API：
+Proxy 通过 WebSocket 直连浏览器（兼容 `chrome://inspect` 方式，无需命令行参数启动），提供 HTTP API：
 
 ```bash
 # 启动（Agent 会自动管理 Proxy 生命周期，无需手动启动）

--- a/README.md
+++ b/README.md
@@ -103,56 +103,32 @@ git clone https://github.com/eze-is/web-access ~/.claude/skills/web-access
 
 ## 前置配置（CDP 模式）
 
-CDP 模式需要 **Node.js 22+** 和浏览器开启远程调试。
-
-先决定用哪种浏览器模式，再进入对应配置：
+CDP 模式需要 **Node.js 22+** 和浏览器开启远程调试。支持两种模式：
 
 | 模式 | 适合场景 | 主要优势 | 主要代价 |
 |------|----------|----------|----------|
-| main browser | 需要立刻复用现有登录态，马上执行任务 | 自动继承现有登录态、书签、插件 | 连接时可能需要处理远程调试授权弹窗；Agent 操作和用户自己的浏览器操作不隔离 |
-| 专用浏览器（dedicated） | 追求 autonomous agent 长时间稳定运行，用户不必一直守在电脑旁 | 通常不需要反复确认远程调试授权；Agent 操作和用户日常浏览隔离 | 首次配置需要单独登录常用网站、安装插件、准备 profile |
+| main browser | 需要立刻复用现有登录态，马上执行任务 | 自动继承现有登录态、书签、插件 | 可能需要处理远程调试授权弹窗；Agent 操作与用户日常浏览不隔离 |
+| 专用浏览器（dedicated） | 追求 autonomous agent 长时间稳定运行 | 通常不需要反复确认调试授权；与日常浏览隔离 | 首次需要单独配置 profile（登录、插件等） |
 
-如果是 Agent 在向用户发起模式选择，不应只给“1 / 2”两个编号。应该把两者的差异、收益和代价直接讲清楚，让用户按自己的场景选择：
-
-- 需要立刻复用现有登录态、马上完成一次任务：通常选 `main browser`
-- 需要把 Agent 操作和日常使用隔离开、希望长期稳定复用同一套环境：通常选 `专用浏览器（dedicated）`
-
-### main browser
-
-1. 在 Chromium 系浏览器地址栏打开 `chrome://inspect/#remote-debugging`
-2. 勾选 **Allow remote debugging for this browser instance**（可能需要重启浏览器）
-
-### 专用浏览器（dedicated）
-
-先选定一个稳定的 `browser-id`：
-
-| browser-id | 浏览器 App 名称 |
-|---|---|
-| `chrome` | `Google Chrome` |
-| `chrome-canary` | `Google Chrome Canary` |
-| `chromium` | `Chromium` |
-| `brave` | `Brave Browser` |
-| `edge` | `Microsoft Edge` |
-| `arc` | `Arc` |
-
-对应的专用 profile 目录固定为：`$HOME/.web-access/<browser-id>-dedicated-profile`
-
-macOS 启动命令示例：
+默认检查命令（推荐）：
 
 ```bash
-open -na "Brave Browser" --args \
-  --remote-debugging-port=9333 \
-  --user-data-dir="$HOME/.web-access/brave-dedicated-profile"
+node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```
 
-专用浏览器启动后，可以显式运行 dedicated 检查命令：
+新流程（默认行为）：
+- 先执行默认检查命令
+- 若 main 与 dedicated 都可用：默认选择 dedicated（除非用户明确要求 main）
+- 若只有一侧可用：直接使用可用一侧
+- 若两侧都不可用：提示用户选择模式并按对应流程配置
+
+需要固定 dedicated 路径时：
 
 ```bash
-node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id brave
-# $CLAUDE_SKILL_DIR 是 skill 加载时自动设置的环境变量
+node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id <chrome|chrome-canary|chromium|brave|edge|arc>
 ```
 
-默认检查命令 `node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"` 会自动检查 main browser 和专用 profile。已经明确进入专用浏览器路径时，后续检查和连接建议继续带上 `--browser dedicated --browser-id ...`，保持路径一致。
+详细配置步骤（main / dedicated）请以 [SKILL.md](./SKILL.md) 的前置检查章节为准。
 
 ## CDP Proxy API
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,7 +22,7 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 
 未通过时引导用户完成设置：
 - **Node.js 22+**：必需（使用原生 WebSocket）。版本低于 22 可用但需安装 `ws` 模块。
-- **Chrome remote-debugging**：在 Chrome 地址栏打开 `chrome://inspect/#remote-debugging`，勾选 **"Allow remote debugging for this browser instance"** 即可，可能需要重启浏览器。
+- **浏览器 remote-debugging**：在浏览器地址栏打开 `chrome://inspect/#remote-debugging`，勾选 **"Allow remote debugging for this browser instance"** 即可，可能需要重启浏览器。
 
 检查通过后并必须在回复中向用户直接展示以下须知，再启动 CDP Proxy 执行操作：
 
@@ -68,9 +68,9 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 
 浏览网页时，**先了解页面结构，再决定下一步动作**。不需要提前规划所有步骤。
 
-### 补充：本地 Chrome 资源
+### 补充：本地浏览器资源（Chrome）
 
-用户指向**本人访问过的页面**（"我之前看的那个讲 X 的文章"、"上次打开过的 XX 面板"）或**组织内部系统**（"我们的 XX 平台"、"公司那个 YY 系统"等公网搜不到的目标）时，检索本地 Chrome 书签/历史：
+用户指向**本人访问过的页面**（"我之前看的那个讲 X 的文章"、"上次打开过的 XX 面板"）或**组织内部系统**（"我们的 XX 平台"、"公司那个 YY 系统"等公网搜不到的目标）时，检索本地浏览器（Chrome）书签/历史：
 
 ```bash
 node "${CLAUDE_SKILL_DIR}/scripts/find-url.mjs" [关键词...] [--only bookmarks|history] [--limit N] [--since 1d|7h|YYYY-MM-DD] [--sort recent|visits]
@@ -91,7 +91,7 @@ node "${CLAUDE_SKILL_DIR}/scripts/find-url.mjs" [关键词...] [--only bookmarks
 
 ## 浏览器 CDP 模式
 
-通过 CDP Proxy 直连用户日常 Chrome，天然携带登录态，无需启动独立浏览器。
+通过 CDP Proxy 直连用户日常浏览器，天然携带登录态，无需启动独立浏览器。
 若无用户明确要求，不主动操作用户已有 tab，所有操作都在自己创建的后台 tab 中进行，保持对用户环境的最小侵入。不关闭用户 tab 的前提下，完成任务后关闭自己创建的 tab，保持环境整洁。
 
 ### 启动
@@ -100,7 +100,7 @@ node "${CLAUDE_SKILL_DIR}/scripts/find-url.mjs" [关键词...] [--only bookmarks
 node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```
 
-脚本会依次检查 Node.js、Chrome 端口，并确保 Proxy 已连接（未运行则自动启动并等待）。Proxy 启动后持续运行。
+脚本会依次检查 Node.js、浏览器调试端口，并确保 Proxy 已连接（未运行则自动启动并等待）。Proxy 启动后持续运行。
 
 ### Proxy API
 
@@ -166,16 +166,16 @@ curl -s "http://localhost:3456/close?target=ID"
 
 ### 视频内容获取
 
-用户 Chrome 真实渲染，截图可捕获当前视频帧。核心能力：通过 `/eval` 操控 `<video>` 元素（获取时长、seek 到任意时间点、播放/暂停/全屏），配合 `/screenshot` 采帧，可对视频内容进行离散采样分析。
+用户浏览器真实渲染，截图可捕获当前视频帧。核心能力：通过 `/eval` 操控 `<video>` 元素（获取时长、seek 到任意时间点、播放/暂停/全屏），配合 `/screenshot` 采帧，可对视频内容进行离散采样分析。
 
 ### 登录判断
 
-用户日常 Chrome 天然携带登录态，大多数常用网站已登录。
+用户日常浏览器天然携带登录态，大多数常用网站已登录。
 
 登录判断的核心问题只有一个：**目标内容拿到了吗？**
 
 打开页面后先尝试获取目标内容。只有当确认**目标内容无法获取**且判断登录能解决时，才告知用户：
-> "当前页面在未登录状态下无法获取[具体内容]，请在你的 Chrome 中登录 [网站名]，完成后告诉我继续。"
+> "当前页面在未登录状态下无法获取[具体内容]，请在你的浏览器中登录 [网站名]，完成后告诉我继续。"
 
 登录完成后无需重启任何东西，直接刷新页面继续。
 
@@ -183,7 +183,7 @@ curl -s "http://localhost:3456/close?target=ID"
 
 用 `/close` 关闭自己创建的 tab，必须保留用户原有的 tab 不受影响。
 
-Proxy 持续运行，不建议主动停止——重启后需要在 Chrome 中重新授权 CDP 连接。
+Proxy 持续运行，不建议主动停止——重启后需要在浏览器中重新授权 CDP 连接。
 
 ## 并行调研：子 Agent 分治策略
 
@@ -193,7 +193,7 @@ Proxy 持续运行，不建议主动停止——重启后需要在 Chrome 中重
 - **速度**：多子 Agent 并行，总耗时约等于单个子任务时长
 - **上下文保护**：抓取内容不进入主 Agent 上下文，主 Agent 只接收摘要，节省 token
 
-**并行 CDP 操作**：每个子 Agent 在当前用户浏览器实例中，自行创建所需的后台 tab（`/new`），自行操作，任务结束自行关闭（`/close`）。所有子 Agent 共享一个 Chrome、一个 Proxy，通过不同 targetId 操作不同 tab，无竞态风险。
+**并行 CDP 操作**：每个子 Agent 在当前用户浏览器实例中，自行创建所需的后台 tab（`/new`），自行操作，任务结束自行关闭（`/close`）。所有子 Agent 共享一个浏览器实例、一个 Proxy，通过不同 targetId 操作不同 tab，无竞态风险。
 
 **子 Agent Prompt 写法：目标导向，而非步骤指令**
 - 必须在子 Agent prompt 中写 `必须加载 web-access skill 并遵循指引` ，子 Agent 会自动加载 skill，无需在 prompt 中复制 skill 内容或指定路径。

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,7 +22,7 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 
 必须遵循以下模式决策流程：
 
-1. **永远先执行默认检查命令**：`node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"`
+1. **首次进入任务或未确定模式时，先执行默认检查命令**：`node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"`
 2. 若检查结果显示 **主力浏览器和专用浏览器都可用**：默认走 **专用浏览器（dedicated）**。只有用户明确要求主力浏览器时才走主力浏览器。
 3. 若只有一侧可用：直接使用可用的一侧。
 4. 若两侧都不可用：再提示用户选择要启用主力浏览器还是专用浏览器，并按选择引导配置。
@@ -32,9 +32,33 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```bash
 node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id <chrome|chrome-canary|chromium|brave|edge|arc>
 ```
-未通过时引导用户完成设置：
-- **Node.js 22+**：必需（使用原生 WebSocket）。版本低于 22 可用但需安装 `ws` 模块。
-- **浏览器 remote-debugging**：在浏览器地址栏打开 `chrome://inspect/#remote-debugging`，勾选 **"Allow remote debugging for this browser instance"** 即可，可能需要重启浏览器。
+未通过时按用户选择给出对应配置流程：
+
+- **通用前提（两种模式都需要）**：Node.js 22+（使用原生 WebSocket）。
+
+- **主力浏览器配置**：
+1. 在 Chromium 系浏览器地址栏打开 `chrome://inspect/#remote-debugging`
+2. 勾选 **Allow remote debugging for this browser instance**（可能需要重启浏览器）
+3. 重新执行默认检查：`node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"`
+
+- **专用浏览器（dedicated）配置**：
+1. 先选一个 `browser-id`（`chrome` / `chrome-canary` / `chromium` / `brave` / `edge` / `arc`）
+2. 专用 profile 目录固定为：`$HOME/.web-access/<browser-id>-dedicated-profile`
+3. 启动该专用浏览器实例并带远程调试参数（macOS 示例）：
+
+```bash
+open -na "Brave Browser" --args \
+  --remote-debugging-port=9333 \
+  --user-data-dir="$HOME/.web-access/brave-dedicated-profile"
+```
+
+4. 重新执行 dedicated 检查：
+
+```bash
+node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id brave
+```
+
+5. 一旦用户明确要求 dedicated 并进入 dedicated 路径，后续检查与连接保持 dedicated 参数，不要混用默认检查命令。
 
 检查通过后并必须在回复中向用户直接展示以下须知，再启动 CDP Proxy 执行操作：
 
@@ -103,7 +127,7 @@ node "${CLAUDE_SKILL_DIR}/scripts/find-url.mjs" [关键词...] [--only bookmarks
 
 ## 浏览器 CDP 模式
 
-通过 CDP Proxy 直连用户日常浏览器，天然携带登录态，无需启动独立浏览器。
+通过 CDP Proxy 直连当前选定的浏览器实例（主力浏览器或专用浏览器），无需启动独立浏览器。
 若无用户明确要求，不主动操作用户已有 tab，所有操作都在自己创建的后台 tab 中进行，保持对用户环境的最小侵入。不关闭用户 tab 的前提下，完成任务后关闭自己创建的 tab，保持环境整洁。
 
 ### 启动
@@ -182,7 +206,7 @@ curl -s "http://localhost:3456/close?target=ID"
 
 ### 登录判断
 
-用户日常浏览器天然携带登录态，大多数常用网站已登录。
+主力浏览器通常天然携带登录态，大多数常用网站已登录。专用浏览器（dedicated）需要一次性手动登录，后续复用同一 profile 可保持登录状态。
 
 登录判断的核心问题只有一个：**目标内容拿到了吗？**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,51 +14,75 @@ metadata:
 
 ## 前置检查
 
-在开始联网操作前，先检查 CDP 模式可用性：
+在开始联网操作前，先执行：
 
 ```bash
 node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```
 
-必须遵循以下模式决策流程：
+必须严格按以下流程处理：
 
-1. **首次进入任务或未确定模式时，先执行默认检查命令**：`node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"`
-2. 若检查结果显示 **主力浏览器和专用浏览器都可用**：默认走 **专用浏览器（dedicated）**。只有用户明确要求主力浏览器时才走主力浏览器。
-3. 若只有一侧可用：直接使用可用的一侧。
-4. 若两侧都不可用：再提示用户选择要启用主力浏览器还是专用浏览器，并按选择引导配置。
+1. 若检查结果显示浏览器 **可用**：
+   - 若 **main browser** 和 **dedicated** 都可用：默认走 **dedicated**。只有用户明确要求主力浏览器时才走 `main browser`。
+   - 若只有一侧可用：直接使用可用的一侧。
+   - 选定模式后，立即开始工作，不要继续让用户做额外配置。
+2. 若检查结果显示两侧都 **不可用**：
+   - 先向用户解释两种模式的差异，让用户选 `main browser` 或 `dedicated`。
+   - 只引导用户配置他选中的那一种，不要两种都讲。
+   - 配置完成后，重新执行检查命令；检查通过后立即开始工作。
 
-用户明确要求专用浏览器时，或需要固定专用浏览器时，检查命令应显式带参数：
+当需要用户选择模式时，按下面的对比说明：
 
-```bash
-node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id <chrome|chrome-canary|chromium|brave|edge|arc>
-```
-未通过时按用户选择给出对应配置流程：
+| 模式 | 适合场景 | 主要优势 | 主要代价 |
+|------|----------|----------|----------|
+| main browser | 需要立刻复用现有登录态，马上执行任务 | 自动继承现有登录态、书签、插件 | 连接时可能需要处理远程调试授权弹窗；Agent 操作和用户自己的浏览器操作不隔离 |
+| 专用浏览器（dedicated） | 追求 autonomous agent 长时间稳定运行，用户不必一直守在电脑旁 | 通常不需要反复确认远程调试授权；Agent 操作和用户日常浏览隔离 | 首次配置需要单独登录常用网站、安装插件、准备 profile |
 
-- **通用前提（两种模式都需要）**：Node.js 22+（使用原生 WebSocket）。
+向用户发起模式选择时，不应只给“1 / 2”两个编号。要直接说明差异、收益和代价，让用户按场景选择：
 
-- **主力浏览器配置**：
+- 需要立刻复用现有登录态、马上完成一次任务：通常选 `main browser`
+- 需要把 Agent 操作和日常使用隔离开、希望长期稳定复用同一套环境：通常选 `专用浏览器（dedicated）`
+
+### main browser
+
 1. 在 Chromium 系浏览器地址栏打开 `chrome://inspect/#remote-debugging`
 2. 勾选 **Allow remote debugging for this browser instance**（可能需要重启浏览器）
-3. 重新执行默认检查：`node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"`
-
-- **专用浏览器（dedicated）配置**：
-1. 先选一个 `browser-id`（`chrome` / `chrome-canary` / `chromium` / `brave` / `edge` / `arc`）
-2. 专用 profile 目录固定为：`$HOME/.web-access/<browser-id>-dedicated-profile`
-3. 启动该专用浏览器实例并带远程调试参数（macOS 示例）：
+3. 完成后重新执行默认检查命令：
 
 ```bash
-open -na "Brave Browser" --args \
-  --remote-debugging-port=9333 \
-  --user-data-dir="$HOME/.web-access/brave-dedicated-profile"
+node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```
 
-4. 重新执行 dedicated 检查：
+### 专用浏览器（dedicated）
+
+1. 先选定一个稳定的 `browser-id`：
+
+| browser-id | 浏览器 App 名称 |
+|---|---|
+| `chrome` | `Google Chrome` |
+| `chrome-canary` | `Google Chrome Canary` |
+| `chromium` | `Chromium` |
+| `brave` | `Brave Browser` |
+| `edge` | `Microsoft Edge` |
+| `arc` | `Arc` |
+
+2. 对应的专用 profile 目录固定为：`$HOME/.web-access/<browser-id>-dedicated-profile`
+
+3. 启动该专用浏览器实例并带远程调试参数。macOS 示例：
+
+```bash
+open -na "<浏览器 App 名称>" --args \
+  --remote-debugging-port=9333 \
+  --user-data-dir="$HOME/.web-access/<browser-id>-dedicated-profile"
+```
+
+4. 启动后重新执行 dedicated 检查命令：
 
 ```bash
 node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id brave
 ```
 
-5. 一旦用户明确要求 dedicated 并进入 dedicated 路径，后续检查与连接保持 dedicated 参数，不要混用默认检查命令。
+已经明确进入 dedicated 路径时，后续检查建议继续显式带上 `--browser dedicated`。`--browser-id` 主要用于帮助检查定位 dedicated profile。
 
 检查通过后并必须在回复中向用户直接展示以下须知，再启动 CDP Proxy 执行操作：
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,6 +20,18 @@ metadata:
 node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```
 
+必须遵循以下模式决策流程：
+
+1. **永远先执行默认检查命令**：`node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"`
+2. 若检查结果显示 **主力浏览器和专用浏览器都可用**：默认走 **专用浏览器（dedicated）**。只有用户明确要求主力浏览器时才走主力浏览器。
+3. 若只有一侧可用：直接使用可用的一侧。
+4. 若两侧都不可用：再提示用户选择要启用主力浏览器还是专用浏览器，并按选择引导配置。
+
+用户明确要求专用浏览器时，或需要固定专用浏览器时，检查命令应显式带参数：
+
+```bash
+node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser dedicated --browser-id <chrome|chrome-canary|chromium|brave|edge|arc>
+```
 未通过时引导用户完成设置：
 - **Node.js 22+**：必需（使用原生 WebSocket）。版本低于 22 可用但需安装 `ws` 模块。
 - **浏览器 remote-debugging**：在浏览器地址栏打开 `chrome://inspect/#remote-debugging`，勾选 **"Allow remote debugging for this browser instance"** 即可，可能需要重启浏览器。

--- a/references/cdp-api.md
+++ b/references/cdp-api.md
@@ -4,7 +4,7 @@
 
 - 地址：`http://localhost:3456`
 - 启动：`node ~/.claude/skills/web-access/scripts/cdp-proxy.mjs &`
-- 启动后持续运行，不建议主动停止（重启需 Chrome 重新授权）
+- 启动后持续运行，不建议主动停止（重启需浏览器重新授权）
 - 强制停止：`pkill -f cdp-proxy.mjs`
 
 ## API 端点
@@ -100,7 +100,7 @@ curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"
 
 | 错误 | 原因 | 解决 |
 |------|------|------|
-| `Chrome 未开启远程调试端口` | Chrome 未开启远程调试 | 提示用户打开 `chrome://inspect/#remote-debugging` 并勾选 Allow |
+| `浏览器未开启远程调试端口` | 浏览器未开启远程调试 | 提示用户打开 `chrome://inspect/#remote-debugging` 并勾选 Allow |
 | `attach 失败` | targetId 无效或 tab 已关闭 | 用 `/targets` 获取最新列表 |
 | `CDP 命令超时` | 页面长时间未响应 | 重试或检查 tab 状态 |
 | `端口已被占用` | 另一个 proxy 已在运行 | 已有实例可直接复用 |

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -1,16 +1,19 @@
 #!/usr/bin/env node
-// CDP Proxy - 通过 HTTP API 操控用户日常 Chrome
-// 要求：Chrome 已开启 --remote-debugging-port
+// CDP Proxy - 通过 HTTP API 操控 Chromium 系浏览器
+// 要求：浏览器已开启 --remote-debugging-port
 // Node.js 22+（使用原生 WebSocket）
 
 import http from 'node:http';
-import { URL } from 'node:url';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
 
 const PORT = parseInt(process.env.CDP_PROXY_PORT || '3456');
+const RAW_BROWSER_MODE = process.env.BROWSER_MODE || 'main';
+const BROWSER_MODE = RAW_BROWSER_MODE === 'primary' ? 'main' : RAW_BROWSER_MODE;
+const BROWSER_ID = process.env.BROWSER_ID || process.env.BROWSER_APP || 'chromium';
+const DEDICATED_PROFILE_DIR = process.env.DEDICATED_PROFILE_DIR || path.join(os.homedir(), '.web-access', `${BROWSER_ID}-dedicated-profile`);
 let ws = null;
 let cmdId = 0;
 const pending = new Map(); // id -> {resolve, timer}
@@ -18,6 +21,7 @@ const sessions = new Map(); // targetId -> sessionId
 const managedTabs = new Map(); // targetId -> { lastAccessed: number }
 const TAB_IDLE_TIMEOUT = parseInt(process.env.CDP_TAB_IDLE_TIMEOUT || '900000'); // 15 min default
 const CLEANUP_INTERVAL = 60000; // sweep every 60s
+let shuttingDown = false;
 
 // --- WebSocket 兼容层 ---
 let WS;
@@ -35,31 +39,50 @@ if (typeof globalThis.WebSocket !== 'undefined') {
   }
 }
 
-// --- 自动发现 Chrome 调试端口 ---
-async function discoverChromePort() {
+// --- 自动发现浏览器调试端口 ---
+async function discoverChromePort(mode = 'main') {
   // 1. 尝试读 DevToolsActivePort 文件
   const possiblePaths = [];
   const platform = os.platform();
 
   if (platform === 'darwin') {
     const home = os.homedir();
-    possiblePaths.push(
-      path.join(home, 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
-      path.join(home, 'Library/Application Support/Google/Chrome Canary/DevToolsActivePort'),
-      path.join(home, 'Library/Application Support/Chromium/DevToolsActivePort'),
-    );
+    if (mode === 'main') {
+      possiblePaths.push(
+        path.join(home, 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
+        path.join(home, 'Library/Application Support/Google/Chrome Canary/DevToolsActivePort'),
+        path.join(home, 'Library/Application Support/Chromium/DevToolsActivePort'),
+        path.join(home, 'Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort'),
+        path.join(home, 'Library/Application Support/Microsoft Edge/DevToolsActivePort'),
+        path.join(home, 'Library/Application Support/Arc/User Data/DevToolsActivePort'),
+      );
+    } else {
+      possiblePaths.push(path.join(DEDICATED_PROFILE_DIR, 'DevToolsActivePort'));
+    }
   } else if (platform === 'linux') {
     const home = os.homedir();
-    possiblePaths.push(
-      path.join(home, '.config/google-chrome/DevToolsActivePort'),
-      path.join(home, '.config/chromium/DevToolsActivePort'),
-    );
+    if (mode === 'main') {
+      possiblePaths.push(
+        path.join(home, '.config/google-chrome/DevToolsActivePort'),
+        path.join(home, '.config/chromium/DevToolsActivePort'),
+        path.join(home, '.config/BraveSoftware/Brave-Browser/DevToolsActivePort'),
+        path.join(home, '.config/microsoft-edge/DevToolsActivePort'),
+      );
+    } else {
+      possiblePaths.push(path.join(DEDICATED_PROFILE_DIR, 'DevToolsActivePort'));
+    }
   } else if (platform === 'win32') {
     const localAppData = process.env.LOCALAPPDATA || '';
-    possiblePaths.push(
-      path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
-      path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
-    );
+    if (mode === 'main') {
+      possiblePaths.push(
+        path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
+        path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
+        path.join(localAppData, 'BraveSoftware/Brave-Browser/User Data/DevToolsActivePort'),
+        path.join(localAppData, 'Microsoft/Edge/User Data/DevToolsActivePort'),
+      );
+    } else {
+      possiblePaths.push(path.join(DEDICATED_PROFILE_DIR, 'DevToolsActivePort'));
+    }
   }
 
   for (const p of possiblePaths) {
@@ -71,7 +94,7 @@ async function discoverChromePort() {
         const ok = await checkPort(port);
         if (ok) {
           // 第二行是带 UUID 的 WebSocket 路径（如 /devtools/browser/xxx-xxx）
-          // 非显式 --remote-debugging-port 启动时，Chrome 可能只接受此路径
+          // 非显式 --remote-debugging-port 启动时，浏览器可能只接受此路径
           const wsPath = lines[1] || null;
           console.log(`[CDP Proxy] 从 DevToolsActivePort 发现端口: ${port}${wsPath ? ' (带 wsPath)' : ''}`);
           return { port, wsPath };
@@ -80,12 +103,16 @@ async function discoverChromePort() {
     } catch { /* 文件不存在，继续 */ }
   }
 
+  if (mode === 'dedicated') {
+    return null;
+  }
+
   // 2. 扫描常用端口
   const commonPorts = [9222, 9229, 9333];
   for (const port of commonPorts) {
     const ok = await checkPort(port);
     if (ok) {
-      console.log(`[CDP Proxy] 扫描发现 Chrome 调试端口: ${port}`);
+      console.log(`[CDP Proxy] 扫描发现浏览器调试端口: ${port}`);
       return { port, wsPath: null };
     }
   }
@@ -93,8 +120,8 @@ async function discoverChromePort() {
   return null;
 }
 
-// 用 TCP 探测端口是否监听——避免 WebSocket 连接触发 Chrome 安全弹窗
-// （WebSocket 探测会被 Chrome 视为调试连接，弹出授权对话框）
+// 用 TCP 探测端口是否监听——避免 WebSocket 连接触发浏览器授权弹窗
+// （WebSocket 探测会被浏览器视为调试连接，弹出授权对话框）
 function checkPort(port) {
   return new Promise((resolve) => {
     const socket = net.createConnection(port, '127.0.0.1');
@@ -104,9 +131,54 @@ function checkPort(port) {
   });
 }
 
+async function fetchJson(url, timeoutMs = 1500) {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    return JSON.parse(await res.text());
+  } catch {
+    return null;
+  }
+}
+
+function parseWsPath(webSocketDebuggerUrl) {
+  if (!webSocketDebuggerUrl) return null;
+  try {
+    const parsed = new URL(webSocketDebuggerUrl);
+    return parsed.pathname || null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveBrowserWsPath(port, fallbackWsPath) {
+  // 统一逻辑：无论 main 还是 dedicated，都是先尝试 /json/version
+  // 取最新 webSocketDebuggerUrl；拿不到时再回退到 DevToolsActivePort 里的 wsPath。
+  const version = await fetchJson(`http://127.0.0.1:${port}/json/version`);
+  const wsPathFromHttp = parseWsPath(version?.webSocketDebuggerUrl);
+  if (wsPathFromHttp) {
+    if (fallbackWsPath && fallbackWsPath !== wsPathFromHttp) {
+      console.log('[CDP Proxy] /json/version 返回了新的 browser wsPath，优先使用它');
+    }
+    return wsPathFromHttp;
+  }
+  return fallbackWsPath;
+}
+
 function getWebSocketUrl(port, wsPath) {
   if (wsPath) return `ws://127.0.0.1:${port}${wsPath}`;
   return `ws://127.0.0.1:${port}/devtools/browser`;
+}
+
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  try {
+    ws?.close?.();
+  } catch {}
+
+  server.close(() => process.exit(code));
+  setTimeout(() => process.exit(code), 500).unref?.();
 }
 
 // --- WebSocket 连接管理 ---
@@ -114,26 +186,26 @@ let chromePort = null;
 let chromeWsPath = null;
 
 let connectingPromise = null;
+
 async function connect() {
   if (ws && (ws.readyState === WS.OPEN || ws.readyState === 1)) return;
   if (connectingPromise) return connectingPromise;  // 复用进行中的连接
 
   if (!chromePort) {
-    const discovered = await discoverChromePort();
+    const discovered = await discoverChromePort(BROWSER_MODE);
     if (!discovered) {
       throw new Error(
-        'Chrome 未开启远程调试端口。请用以下方式启动 Chrome：\n' +
-        '  macOS: /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222\n' +
-        '  Linux: google-chrome --remote-debugging-port=9222\n' +
-        '  或在 chrome://flags 中搜索 "remote debugging" 并启用'
+          BROWSER_MODE === 'main'
+          ? 'main browser 未开启远程调试。请先在 Chromium 系浏览器中开启 remote debugging。'
+          : `专用浏览器未开启远程调试。请先启动使用该 profile 的浏览器：${DEDICATED_PROFILE_DIR}`
       );
     }
     chromePort = discovered.port;
-    chromeWsPath = discovered.wsPath;
+    chromeWsPath = await resolveBrowserWsPath(discovered.port, discovered.wsPath);
   }
 
   const wsUrl = getWebSocketUrl(chromePort, chromeWsPath);
-  if (!wsUrl) throw new Error('无法获取 Chrome WebSocket URL');
+  if (!wsUrl) throw new Error('无法获取浏览器 WebSocket URL');
 
   return connectingPromise = new Promise((resolve, reject) => {
     ws = new WS(wsUrl);
@@ -141,7 +213,7 @@ async function connect() {
     const onOpen = () => {
       cleanup();
       connectingPromise = null;
-      console.log(`[CDP Proxy] 已连接 Chrome (端口 ${chromePort})`);
+      console.log(`[CDP Proxy] 已连接浏览器 (端口 ${chromePort})`);
       resolve();
     };
     const onError = (e) => {
@@ -170,7 +242,7 @@ async function connect() {
         const { sessionId, targetInfo } = msg.params;
         sessions.set(targetInfo.targetId, sessionId);
       }
-      // 拦截页面对 Chrome 调试端口的探测请求（反风控）
+      // 拦截页面对浏览器调试端口的探测请求（反风控）
       if (msg.method === 'Fetch.requestPaused') {
         const { requestId, sessionId: sid } = msg.params;
         sendCDP('Fetch.failRequest', { requestId, errorReason: 'ConnectionRefused' }, sid).catch(() => {});
@@ -236,7 +308,7 @@ async function ensureSession(targetId) {
   throw new Error('attach 失败: ' + JSON.stringify(resp.error));
 }
 
-// 拦截页面对 Chrome 调试端口的探测（反风控）
+// 拦截页面对浏览器调试端口的探测（反风控）
 // 只拦截 127.0.0.1:{chromePort} 的请求，不影响其他任何本地服务
 async function enablePortGuard(sessionId) {
   if (!chromePort || portGuardedSessions.has(sessionId)) return;
@@ -327,10 +399,20 @@ const server = http.createServer(async (req, res) => {
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
 
   try {
-    // /health 不需要连接 Chrome
+    // /health 不需要连接浏览器
     if (pathname === '/health') {
       const connected = ws && (ws.readyState === WS.OPEN || ws.readyState === 1);
+<<<<<<< HEAD
       res.end(JSON.stringify({ status: 'ok', connected, sessions: sessions.size, managedTabs: managedTabs.size, chromePort }));
+=======
+      res.end(JSON.stringify({ status: 'ok', connected, browserMode: BROWSER_MODE, sessions: sessions.size, chromePort }));
+      return;
+    }
+
+    if (pathname === '/shutdown') {
+      res.end(JSON.stringify({ status: 'ok', shuttingDown: true }));
+      setTimeout(() => shutdown(0), 50).unref?.();
+>>>>>>> 7d3fa59 (feat(cdp): add dedicated browser mode and standardize main browser wording)
       return;
     }
 
@@ -621,7 +703,7 @@ async function main() {
 
   server.listen(PORT, '127.0.0.1', () => {
     console.log(`[CDP Proxy] 运行在 http://localhost:${PORT}`);
-    // 启动时尝试连接 Chrome（非阻塞）
+    // 启动时尝试连接浏览器（非阻塞）
     connect().catch(e => console.error('[CDP Proxy] 初始连接失败:', e.message, '（将在首次请求时重试）'));
   });
 

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -102,21 +102,6 @@ async function discoverChromePort(mode = 'main') {
       }
     } catch { /* 文件不存在，继续 */ }
   }
-
-  if (mode === 'dedicated') {
-    return null;
-  }
-
-  // 2. 扫描常用端口
-  const commonPorts = [9222, 9229, 9333];
-  for (const port of commonPorts) {
-    const ok = await checkPort(port);
-    if (ok) {
-      console.log(`[CDP Proxy] 扫描发现浏览器调试端口: ${port}`);
-      return { port, wsPath: null };
-    }
-  }
-
   return null;
 }
 
@@ -402,17 +387,20 @@ const server = http.createServer(async (req, res) => {
     // /health 不需要连接浏览器
     if (pathname === '/health') {
       const connected = ws && (ws.readyState === WS.OPEN || ws.readyState === 1);
-<<<<<<< HEAD
-      res.end(JSON.stringify({ status: 'ok', connected, sessions: sessions.size, managedTabs: managedTabs.size, chromePort }));
-=======
-      res.end(JSON.stringify({ status: 'ok', connected, browserMode: BROWSER_MODE, sessions: sessions.size, chromePort }));
+      res.end(JSON.stringify({
+        status: 'ok',
+        connected,
+        browserMode: BROWSER_MODE,
+        sessions: sessions.size,
+        managedTabs: managedTabs.size,
+        chromePort,
+      }));
       return;
     }
 
     if (pathname === '/shutdown') {
       res.end(JSON.stringify({ status: 'ok', shuttingDown: true }));
       setTimeout(() => shutdown(0), 50).unref?.();
->>>>>>> 7d3fa59 (feat(cdp): add dedicated browser mode and standardize main browser wording)
       return;
     }
 

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -11,7 +11,7 @@ import net from 'node:net';
 
 const PORT = parseInt(process.env.CDP_PROXY_PORT || '3456');
 const RAW_BROWSER_MODE = process.env.BROWSER_MODE || 'main';
-const BROWSER_MODE = RAW_BROWSER_MODE === 'primary' ? 'main' : RAW_BROWSER_MODE;
+const BROWSER_MODE = RAW_BROWSER_MODE;
 const BROWSER_ID = process.env.BROWSER_ID || process.env.BROWSER_APP || 'chromium';
 const DEDICATED_PROFILE_DIR = process.env.DEDICATED_PROFILE_DIR || path.join(os.homedir(), '.web-access', `${BROWSER_ID}-dedicated-profile`);
 let ws = null;

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -11,7 +11,8 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PROXY_SCRIPT = path.join(ROOT, 'scripts', 'cdp-proxy.mjs');
 const PROXY_PORT = Number(process.env.CDP_PROXY_PORT || 3456);
-const ALLOWED_BROWSER_IDS = new Set(['chrome', 'chrome-canary', 'chromium', 'brave', 'edge', 'arc']);
+const ALLOWED_BROWSER_IDS = ['chrome', 'chrome-canary', 'chromium', 'brave', 'edge', 'arc'];
+const ALLOWED_BROWSER_ID_SET = new Set(ALLOWED_BROWSER_IDS);
 
 function defaultDedicatedProfileDir(browserId) {
   return path.join(os.homedir(), '.web-access', `${browserId}-dedicated-profile`);
@@ -19,7 +20,8 @@ function defaultDedicatedProfileDir(browserId) {
 
 function parseArgs(argv) {
   const options = {
-    browser: process.env.BROWSER_MODE || 'main',
+    browser: null,
+    browserSpecified: false,
     browserId: process.env.BROWSER_ID || process.env.BROWSER_APP || null,
     dedicatedProfileDir: process.env.DEDICATED_PROFILE_DIR || null,
   };
@@ -28,6 +30,7 @@ function parseArgs(argv) {
     const arg = argv[index];
     if (arg === '--browser') {
       options.browser = argv[index + 1] || options.browser;
+      options.browserSpecified = true;
       index += 1;
       continue;
     }
@@ -43,21 +46,21 @@ function parseArgs(argv) {
     }
     if (arg === '--help' || arg === '-h') {
       console.log('Usage: node check-deps.mjs [--browser main|dedicated] [--browser-id <id>] [--dedicated-profile-dir <path>]');
+      console.log('Default behavior (no --browser): auto-pick mode. dedicated preferred when both available.');
       process.exit(0);
     }
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  if (!['main', 'dedicated'].includes(options.browser)) {
+  if (options.browserSpecified && !['main', 'dedicated'].includes(options.browser)) {
     throw new Error(`Invalid browser mode: ${options.browser}`);
   }
-
 
   if (options.browser === 'dedicated') {
     if (!options.browserId) {
       throw new Error('Dedicated mode requires --browser-id <chrome|chrome-canary|chromium|brave|edge|arc>');
     }
-    if (!ALLOWED_BROWSER_IDS.has(options.browserId)) {
+    if (!ALLOWED_BROWSER_ID_SET.has(options.browserId)) {
       throw new Error(`Invalid browser id: ${options.browserId}`);
     }
     options.dedicatedProfileDir = options.dedicatedProfileDir || defaultDedicatedProfileDir(options.browserId);
@@ -67,8 +70,6 @@ function parseArgs(argv) {
 }
 
 const OPTIONS = parseArgs(process.argv.slice(2));
-
-// --- Node.js 版本检查 ---
 
 function checkNode() {
   const major = Number(process.versions.node.split('.')[0]);
@@ -80,8 +81,6 @@ function checkNode() {
   }
 }
 
-// --- TCP 端口探测 ---
-
 function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
   return new Promise((resolve) => {
     const socket = net.createConnection(port, host);
@@ -91,14 +90,12 @@ function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
   });
 }
 
-// --- 浏览器调试端口检测（DevToolsActivePort 多路径 + 常见端口回退） ---
-
-function activePortFiles() {
+function activePortFiles(browser, dedicatedProfileDir) {
   const home = os.homedir();
   const localAppData = process.env.LOCALAPPDATA || '';
   switch (os.platform()) {
     case 'darwin':
-      return OPTIONS.browser === 'main'
+      return browser === 'main'
         ? [
             path.join(home, 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
             path.join(home, 'Library/Application Support/Google/Chrome Canary/DevToolsActivePort'),
@@ -107,33 +104,32 @@ function activePortFiles() {
             path.join(home, 'Library/Application Support/Microsoft Edge/DevToolsActivePort'),
             path.join(home, 'Library/Application Support/Arc/User Data/DevToolsActivePort'),
           ]
-        : [path.join(OPTIONS.dedicatedProfileDir, 'DevToolsActivePort')];
+        : [path.join(dedicatedProfileDir, 'DevToolsActivePort')];
     case 'linux':
-      return OPTIONS.browser === 'main'
+      return browser === 'main'
         ? [
             path.join(home, '.config/google-chrome/DevToolsActivePort'),
             path.join(home, '.config/chromium/DevToolsActivePort'),
             path.join(home, '.config/BraveSoftware/Brave-Browser/DevToolsActivePort'),
             path.join(home, '.config/microsoft-edge/DevToolsActivePort'),
           ]
-        : [path.join(OPTIONS.dedicatedProfileDir, 'DevToolsActivePort')];
+        : [path.join(dedicatedProfileDir, 'DevToolsActivePort')];
     case 'win32':
-      return OPTIONS.browser === 'main'
+      return browser === 'main'
         ? [
             path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
             path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
             path.join(localAppData, 'BraveSoftware/Brave-Browser/User Data/DevToolsActivePort'),
             path.join(localAppData, 'Microsoft/Edge/User Data/DevToolsActivePort'),
           ]
-        : [path.join(OPTIONS.dedicatedProfileDir, 'DevToolsActivePort')];
+        : [path.join(dedicatedProfileDir, 'DevToolsActivePort')];
     default:
       return [];
   }
 }
 
-async function detectChromePort() {
-  // 优先从 DevToolsActivePort 文件读取
-  for (const filePath of activePortFiles()) {
+async function detectChromePort(browser, dedicatedProfileDir = '') {
+  for (const filePath of activePortFiles(browser, dedicatedProfileDir)) {
     try {
       const lines = fs.readFileSync(filePath, 'utf8').trim().split(/\r?\n/).filter(Boolean);
       const port = parseInt(lines[0], 10);
@@ -142,11 +138,11 @@ async function detectChromePort() {
       }
     } catch (_) {}
   }
-  if (OPTIONS.browser === 'dedicated') {
+
+  if (browser === 'dedicated') {
     return null;
   }
 
-  // 回退：探测常见端口
   for (const port of [9222, 9229, 9333]) {
     if (await checkPort(port)) {
       return port;
@@ -154,8 +150,6 @@ async function detectChromePort() {
   }
   return null;
 }
-
-// --- CDP Proxy 启动与等待 ---
 
 function httpGetJson(url, timeoutMs = 3000) {
   return fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
@@ -165,15 +159,15 @@ function httpGetJson(url, timeoutMs = 3000) {
     .catch(() => null);
 }
 
-function startProxyDetached() {
+function startProxyDetached(runtime) {
   const logFile = path.join(os.tmpdir(), 'cdp-proxy.log');
   const logFd = fs.openSync(logFile, 'a');
   const child = spawn(process.execPath, [PROXY_SCRIPT], {
     env: {
       ...process.env,
-      BROWSER_MODE: OPTIONS.browser,
-      BROWSER_ID: OPTIONS.browserId || '',
-      DEDICATED_PROFILE_DIR: OPTIONS.dedicatedProfileDir || '',
+      BROWSER_MODE: runtime.browser,
+      BROWSER_ID: runtime.browserId || '',
+      DEDICATED_PROFILE_DIR: runtime.dedicatedProfileDir || '',
     },
     detached: true,
     stdio: ['ignore', logFd, logFd],
@@ -183,7 +177,7 @@ function startProxyDetached() {
   fs.closeSync(logFd);
 }
 
-async function ensureProxy() {
+async function ensureProxy(runtime) {
   const healthUrl = `http://127.0.0.1:${PROXY_PORT}/health`;
   const shutdownUrl = `http://127.0.0.1:${PROXY_PORT}/shutdown`;
   const targetsUrl = `http://127.0.0.1:${PROXY_PORT}/targets`;
@@ -191,31 +185,28 @@ async function ensureProxy() {
   const health = await httpGetJson(healthUrl);
   if (
     health?.status === 'ok' &&
-    health.browserMode === OPTIONS.browser &&
+    health.browserMode === runtime.browser &&
     health.connected === true
   ) {
     console.log('proxy: ready');
     return true;
   }
 
-  if (health?.status === 'ok' && health.browserMode && health.browserMode !== OPTIONS.browser) {
-    console.log(`proxy: restarting from ${health.browserMode} to ${OPTIONS.browser}`);
+  if (health?.status === 'ok' && health.browserMode && health.browserMode !== runtime.browser) {
+    console.log(`proxy: restarting from ${health.browserMode} to ${runtime.browser}`);
     await httpGetJson(shutdownUrl, 2000);
     await new Promise((r) => setTimeout(r, 1000));
   }
 
-  // /targets 返回 JSON 数组即 ready
   const targets = await httpGetJson(targetsUrl);
   if (Array.isArray(targets)) {
     console.log('proxy: ready');
     return true;
   }
 
-  // 未运行或未连接，启动并等待
   console.log('proxy: connecting...');
-  startProxyDetached();
+  startProxyDetached(runtime);
 
-  // 等 proxy 进程就绪
   await new Promise((r) => setTimeout(r, 2000));
 
   for (let i = 1; i <= 15; i++) {
@@ -225,7 +216,7 @@ async function ensureProxy() {
       return true;
     }
     if (i === 1) {
-      if (OPTIONS.browser === 'main') {
+      if (runtime.browser === 'main') {
         console.log('⚠️  main browser 模式下，可能有远程调试授权弹窗，请点击「允许」后等待连接...');
       } else {
         console.log('⚠️  专用浏览器模式下通常不会有授权弹窗；若持续超时，请检查 dedicated profile 路径和启动参数是否一致。');
@@ -239,31 +230,90 @@ async function ensureProxy() {
   return false;
 }
 
-// --- main ---
+function preferredDedicatedIds() {
+  const preferred = [];
+  if (OPTIONS.browserId && ALLOWED_BROWSER_ID_SET.has(OPTIONS.browserId)) {
+    preferred.push(OPTIONS.browserId);
+  }
+  for (const id of ALLOWED_BROWSER_IDS) {
+    if (!preferred.includes(id)) preferred.push(id);
+  }
+  return preferred;
+}
+
+async function detectFirstDedicatedAvailable() {
+  for (const browserId of preferredDedicatedIds()) {
+    const profile = defaultDedicatedProfileDir(browserId);
+    const port = await detectChromePort('dedicated', profile);
+    if (port) {
+      return { browser: 'dedicated', browserId, dedicatedProfileDir: profile, port };
+    }
+  }
+  return null;
+}
+
+async function resolveRuntime() {
+  if (OPTIONS.browserSpecified) {
+    if (OPTIONS.browser === 'main') {
+      const port = await detectChromePort('main');
+      if (!port) {
+        console.log('browser: not connected (main mode)');
+        console.log('请先开启 main browser 的远程调试，或改为 dedicated 模式。');
+        return null;
+      }
+      return { browser: 'main', browserId: null, dedicatedProfileDir: null, port };
+    }
+
+    const dedicatedProfileDir = OPTIONS.dedicatedProfileDir || defaultDedicatedProfileDir(OPTIONS.browserId);
+    const port = await detectChromePort('dedicated', dedicatedProfileDir);
+    if (!port) {
+      console.log('browser: not connected (dedicated mode)');
+      console.log('请先启动专用浏览器，或检查 dedicated profile 路径是否正确：');
+      console.log(`  browserId: ${OPTIONS.browserId}`);
+      console.log(`  profile: ${dedicatedProfileDir}`);
+      return null;
+    }
+    return { browser: 'dedicated', browserId: OPTIONS.browserId, dedicatedProfileDir, port };
+  }
+
+  const mainPort = await detectChromePort('main');
+  const dedicated = await detectFirstDedicatedAvailable();
+
+  if (mainPort && dedicated) {
+    console.log(`browser: both available (main + dedicated:${dedicated.browserId}) -> selected dedicated`);
+    return dedicated;
+  }
+  if (dedicated) {
+    console.log(`browser: dedicated available (${dedicated.browserId}) -> selected dedicated`);
+    return dedicated;
+  }
+  if (mainPort) {
+    console.log('browser: only main available -> selected main');
+    return { browser: 'main', browserId: null, dedicatedProfileDir: null, port: mainPort };
+  }
+
+  console.log('browser: none available');
+  console.log('请让用户选择浏览器模式后再继续：');
+  console.log('- 选主力浏览器：先在主力浏览器开启 remote debugging，然后重跑 check-deps。');
+  console.log('- 选专用浏览器：先启动 dedicated profile（带 --remote-debugging-port），再重跑 check-deps。');
+  return null;
+}
 
 async function main() {
   checkNode();
 
-  const chromePort = await detectChromePort();
-  if (!chromePort) {
-    if (OPTIONS.browser === 'main') {
-      console.log('browser: not connected (main mode) — 请先让用户决定：开启当前 main browser 的远程调试，或明确切换到专用浏览器；不要自动改走专用浏览器路径。');
-    } else {
-      console.log('browser: not connected (dedicated mode)');
-      console.log('请先启动专用浏览器，或检查 dedicated profile 路径是否正确：');
-      console.log(`  browserId: ${OPTIONS.browserId}`);
-      console.log(`  profile: ${OPTIONS.dedicatedProfileDir}`);
-    }
+  const runtime = await resolveRuntime();
+  if (!runtime) {
     process.exit(1);
   }
-  console.log(`browser: ok (port ${chromePort}, ${OPTIONS.browser} mode)`);
 
-  const proxyOk = await ensureProxy();
+  console.log(`browser: ok (port ${runtime.port}, ${runtime.browser} mode${runtime.browserId ? `, ${runtime.browserId}` : ''})`);
+
+  const proxyOk = await ensureProxy(runtime);
   if (!proxyOk) {
     process.exit(1);
   }
 
-  // 列出已有站点经验
   const patternsDir = path.join(ROOT, 'references', 'site-patterns');
   try {
     const sites = fs.readdirSync(patternsDir)
@@ -273,7 +323,6 @@ async function main() {
       console.log(`\nsite-patterns: ${sites.join(', ')}`);
     }
   } catch {}
-
 }
 
 await main();

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// 环境检查 + 确保 CDP Proxy 就绪（跨平台，替代 check-deps.sh）
+// 环境检查 + 确保 CDP Proxy 就绪（跨平台，替代 check-deps.mjs）
 
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
@@ -11,6 +11,63 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PROXY_SCRIPT = path.join(ROOT, 'scripts', 'cdp-proxy.mjs');
 const PROXY_PORT = Number(process.env.CDP_PROXY_PORT || 3456);
+const ALLOWED_BROWSER_IDS = new Set(['chrome', 'chrome-canary', 'chromium', 'brave', 'edge', 'arc']);
+
+function defaultDedicatedProfileDir(browserId) {
+  return path.join(os.homedir(), '.web-access', `${browserId}-dedicated-profile`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    browser: process.env.BROWSER_MODE || 'main',
+    browserId: process.env.BROWSER_ID || process.env.BROWSER_APP || null,
+    dedicatedProfileDir: process.env.DEDICATED_PROFILE_DIR || null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--browser') {
+      options.browser = argv[index + 1] || options.browser;
+      index += 1;
+      continue;
+    }
+    if (arg === '--browser-id' || arg === '--browser-app') {
+      options.browserId = argv[index + 1] || options.browserId;
+      index += 1;
+      continue;
+    }
+    if (arg === '--dedicated-profile-dir') {
+      options.dedicatedProfileDir = argv[index + 1] || options.dedicatedProfileDir;
+      index += 1;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node check-deps.mjs [--browser main|dedicated] [--browser-id <id>] [--dedicated-profile-dir <path>]');
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!['main', 'primary', 'dedicated'].includes(options.browser)) {
+    throw new Error(`Invalid browser mode: ${options.browser}`);
+  }
+
+  if (options.browser === 'primary') options.browser = 'main';
+
+  if (options.browser === 'dedicated') {
+    if (!options.browserId) {
+      throw new Error('Dedicated mode requires --browser-id <chrome|chrome-canary|chromium|brave|edge|arc>');
+    }
+    if (!ALLOWED_BROWSER_IDS.has(options.browserId)) {
+      throw new Error(`Invalid browser id: ${options.browserId}`);
+    }
+    options.dedicatedProfileDir = options.dedicatedProfileDir || defaultDedicatedProfileDir(options.browserId);
+  }
+
+  return options;
+}
+
+const OPTIONS = parseArgs(process.argv.slice(2));
 
 // --- Node.js 版本检查 ---
 
@@ -35,28 +92,41 @@ function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
   });
 }
 
-// --- Chrome 调试端口检测（DevToolsActivePort 多路径 + 常见端口回退） ---
+// --- 浏览器调试端口检测（DevToolsActivePort 多路径 + 常见端口回退） ---
 
 function activePortFiles() {
   const home = os.homedir();
   const localAppData = process.env.LOCALAPPDATA || '';
   switch (os.platform()) {
     case 'darwin':
-      return [
-        path.join(home, 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
-        path.join(home, 'Library/Application Support/Google/Chrome Canary/DevToolsActivePort'),
-        path.join(home, 'Library/Application Support/Chromium/DevToolsActivePort'),
-      ];
+      return OPTIONS.browser === 'main'
+        ? [
+            path.join(home, 'Library/Application Support/Google/Chrome/DevToolsActivePort'),
+            path.join(home, 'Library/Application Support/Google/Chrome Canary/DevToolsActivePort'),
+            path.join(home, 'Library/Application Support/Chromium/DevToolsActivePort'),
+            path.join(home, 'Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort'),
+            path.join(home, 'Library/Application Support/Microsoft Edge/DevToolsActivePort'),
+            path.join(home, 'Library/Application Support/Arc/User Data/DevToolsActivePort'),
+          ]
+        : [path.join(OPTIONS.dedicatedProfileDir, 'DevToolsActivePort')];
     case 'linux':
-      return [
-        path.join(home, '.config/google-chrome/DevToolsActivePort'),
-        path.join(home, '.config/chromium/DevToolsActivePort'),
-      ];
+      return OPTIONS.browser === 'main'
+        ? [
+            path.join(home, '.config/google-chrome/DevToolsActivePort'),
+            path.join(home, '.config/chromium/DevToolsActivePort'),
+            path.join(home, '.config/BraveSoftware/Brave-Browser/DevToolsActivePort'),
+            path.join(home, '.config/microsoft-edge/DevToolsActivePort'),
+          ]
+        : [path.join(OPTIONS.dedicatedProfileDir, 'DevToolsActivePort')];
     case 'win32':
-      return [
-        path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
-        path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
-      ];
+      return OPTIONS.browser === 'main'
+        ? [
+            path.join(localAppData, 'Google/Chrome/User Data/DevToolsActivePort'),
+            path.join(localAppData, 'Chromium/User Data/DevToolsActivePort'),
+            path.join(localAppData, 'BraveSoftware/Brave-Browser/User Data/DevToolsActivePort'),
+            path.join(localAppData, 'Microsoft/Edge/User Data/DevToolsActivePort'),
+          ]
+        : [path.join(OPTIONS.dedicatedProfileDir, 'DevToolsActivePort')];
     default:
       return [];
   }
@@ -73,6 +143,10 @@ async function detectChromePort() {
       }
     } catch (_) {}
   }
+  if (OPTIONS.browser === 'dedicated') {
+    return null;
+  }
+
   // 回退：探测常见端口
   for (const port of [9222, 9229, 9333]) {
     if (await checkPort(port)) {
@@ -96,6 +170,12 @@ function startProxyDetached() {
   const logFile = path.join(os.tmpdir(), 'cdp-proxy.log');
   const logFd = fs.openSync(logFile, 'a');
   const child = spawn(process.execPath, [PROXY_SCRIPT], {
+    env: {
+      ...process.env,
+      BROWSER_MODE: OPTIONS.browser,
+      BROWSER_ID: OPTIONS.browserId || '',
+      DEDICATED_PROFILE_DIR: OPTIONS.dedicatedProfileDir || '',
+    },
     detached: true,
     stdio: ['ignore', logFd, logFd],
     ...(os.platform() === 'win32' ? { windowsHide: true } : {}),
@@ -105,7 +185,25 @@ function startProxyDetached() {
 }
 
 async function ensureProxy() {
+  const healthUrl = `http://127.0.0.1:${PROXY_PORT}/health`;
+  const shutdownUrl = `http://127.0.0.1:${PROXY_PORT}/shutdown`;
   const targetsUrl = `http://127.0.0.1:${PROXY_PORT}/targets`;
+
+  const health = await httpGetJson(healthUrl);
+  if (
+    health?.status === 'ok' &&
+    health.browserMode === OPTIONS.browser &&
+    health.connected === true
+  ) {
+    console.log('proxy: ready');
+    return true;
+  }
+
+  if (health?.status === 'ok' && health.browserMode && health.browserMode !== OPTIONS.browser) {
+    console.log(`proxy: restarting from ${health.browserMode} to ${OPTIONS.browser}`);
+    await httpGetJson(shutdownUrl, 2000);
+    await new Promise((r) => setTimeout(r, 1000));
+  }
 
   // /targets 返回 JSON 数组即 ready
   const targets = await httpGetJson(targetsUrl);
@@ -128,12 +226,16 @@ async function ensureProxy() {
       return true;
     }
     if (i === 1) {
-      console.log('⚠️  Chrome 可能有授权弹窗，请点击「允许」后等待连接...');
+      if (OPTIONS.browser === 'main') {
+        console.log('⚠️  main browser 模式下，可能有远程调试授权弹窗，请点击「允许」后等待连接...');
+      } else {
+        console.log('⚠️  专用浏览器模式下通常不会有授权弹窗；若持续超时，请检查 dedicated profile 路径和启动参数是否一致。');
+      }
     }
     await new Promise((r) => setTimeout(r, 1000));
   }
 
-  console.log('❌ 连接超时，请检查 Chrome 调试设置');
+  console.log('❌ 连接超时，请检查浏览器调试设置');
   console.log(`  日志：${path.join(os.tmpdir(), 'cdp-proxy.log')}`);
   return false;
 }
@@ -145,10 +247,17 @@ async function main() {
 
   const chromePort = await detectChromePort();
   if (!chromePort) {
-    console.log('chrome: not connected — 请确保 Chrome 已打开，然后访问 chrome://inspect/#remote-debugging 并勾选 Allow remote debugging');
+    if (OPTIONS.browser === 'main') {
+      console.log('browser: not connected (main mode) — 请先让用户决定：开启当前 main browser 的远程调试，或明确切换到专用浏览器；不要自动改走专用浏览器路径。');
+    } else {
+      console.log('browser: not connected (dedicated mode)');
+      console.log('请先启动专用浏览器，或检查 dedicated profile 路径是否正确：');
+      console.log(`  browserId: ${OPTIONS.browserId}`);
+      console.log(`  profile: ${OPTIONS.dedicatedProfileDir}`);
+    }
     process.exit(1);
   }
-  console.log(`chrome: ok (port ${chromePort})`);
+  console.log(`browser: ok (port ${chromePort}, ${OPTIONS.browser} mode)`);
 
   const proxyOk = await ensureProxy();
   if (!proxyOk) {

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -48,11 +48,10 @@ function parseArgs(argv) {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  if (!['main', 'primary', 'dedicated'].includes(options.browser)) {
+  if (!['main', 'dedicated'].includes(options.browser)) {
     throw new Error(`Invalid browser mode: ${options.browser}`);
   }
 
-  if (options.browser === 'primary') options.browser = 'main';
 
   if (options.browser === 'dedicated') {
     if (!options.browserId) {

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -14,6 +14,19 @@ const PROXY_PORT = Number(process.env.CDP_PROXY_PORT || 3456);
 const ALLOWED_BROWSER_IDS = ['chrome', 'chrome-canary', 'chromium', 'brave', 'edge', 'arc'];
 const ALLOWED_BROWSER_ID_SET = new Set(ALLOWED_BROWSER_IDS);
 
+function log(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+function printJson(result) {
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function fail(result, exitCode = 1) {
+  printJson({ ok: false, ...result });
+  process.exit(exitCode);
+}
+
 function defaultDedicatedProfileDir(browserId) {
   return path.join(os.homedir(), '.web-access', `${browserId}-dedicated-profile`);
 }
@@ -45,8 +58,12 @@ function parseArgs(argv) {
       continue;
     }
     if (arg === '--help' || arg === '-h') {
-      console.log('Usage: node check-deps.mjs [--browser main|dedicated] [--browser-id <id>] [--dedicated-profile-dir <path>]');
-      console.log('Default behavior (no --browser): auto-pick mode. dedicated preferred when both available.');
+      printJson({
+        ok: true,
+        help: true,
+        usage: 'node check-deps.mjs [--browser main|dedicated] [--browser-id <id>] [--dedicated-profile-dir <path>]',
+        defaultBehavior: 'auto-pick mode; dedicated preferred when both available',
+      });
       process.exit(0);
     }
     throw new Error(`Unknown argument: ${arg}`);
@@ -75,10 +92,15 @@ function checkNode() {
   const major = Number(process.versions.node.split('.')[0]);
   const version = `v${process.versions.node}`;
   if (major >= 22) {
-    console.log(`node: ok (${version})`);
+    log(`node: ok (${version})`);
   } else {
-    console.log(`node: warn (${version}, 建议升级到 22+)`);
+    log(`node: warn (${version}, 建议升级到 22+)`);
   }
+  return {
+    ok: major >= 22,
+    version,
+    recommendation: major >= 22 ? null : '建议升级到 22+',
+  };
 }
 
 function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
@@ -138,16 +160,6 @@ async function detectChromePort(browser, dedicatedProfileDir = '') {
       }
     } catch (_) {}
   }
-
-  if (browser === 'dedicated') {
-    return null;
-  }
-
-  for (const port of [9222, 9229, 9333]) {
-    if (await checkPort(port)) {
-      return port;
-    }
-  }
   return null;
 }
 
@@ -188,46 +200,54 @@ async function ensureProxy(runtime) {
     health.browserMode === runtime.browser &&
     health.connected === true
   ) {
-    console.log('proxy: ready');
-    return true;
+    log('proxy: ready');
+    return { ok: true, reusedExisting: true, restartedForModeSwitch: false };
   }
 
+  let restartedForModeSwitch = false;
   if (health?.status === 'ok' && health.browserMode && health.browserMode !== runtime.browser) {
-    console.log(`proxy: restarting from ${health.browserMode} to ${runtime.browser}`);
+    log(`proxy: restarting from ${health.browserMode} to ${runtime.browser}`);
     await httpGetJson(shutdownUrl, 2000);
     await new Promise((r) => setTimeout(r, 1000));
+    restartedForModeSwitch = true;
   }
 
   const targets = await httpGetJson(targetsUrl);
   if (Array.isArray(targets)) {
-    console.log('proxy: ready');
-    return true;
+    log('proxy: ready');
+    return { ok: true, reusedExisting: true, restartedForModeSwitch };
   }
 
-  console.log('proxy: connecting...');
+  log('proxy: connecting...');
   startProxyDetached(runtime);
 
   await new Promise((r) => setTimeout(r, 2000));
 
+  let hint = null;
   for (let i = 1; i <= 15; i++) {
     const result = await httpGetJson(targetsUrl, 8000);
     if (Array.isArray(result)) {
-      console.log('proxy: ready');
-      return true;
+      log('proxy: ready');
+      return { ok: true, reusedExisting: false, restartedForModeSwitch, hint };
     }
     if (i === 1) {
-      if (runtime.browser === 'main') {
-        console.log('⚠️  main browser 模式下，可能有远程调试授权弹窗，请点击「允许」后等待连接...');
-      } else {
-        console.log('⚠️  专用浏览器模式下通常不会有授权弹窗；若持续超时，请检查 dedicated profile 路径和启动参数是否一致。');
-      }
+      hint = runtime.browser === 'main'
+        ? 'main browser 模式下，可能有远程调试授权弹窗，请点击“允许”后等待连接'
+        : '专用浏览器模式下通常不会有授权弹窗；若持续超时，请检查 dedicated profile 路径和启动参数是否一致';
+      log(`warning: ${hint}`);
     }
     await new Promise((r) => setTimeout(r, 1000));
   }
 
-  console.log('❌ 连接超时，请检查浏览器调试设置');
-  console.log(`  日志：${path.join(os.tmpdir(), 'cdp-proxy.log')}`);
-  return false;
+  log('proxy: timeout');
+  return {
+    ok: false,
+    reusedExisting: false,
+    restartedForModeSwitch,
+    hint,
+    reason: 'proxy_connect_timeout',
+    logFile: path.join(os.tmpdir(), 'cdp-proxy.log'),
+  };
 }
 
 function preferredDedicatedIds() {
@@ -257,72 +277,160 @@ async function resolveRuntime() {
     if (OPTIONS.browser === 'main') {
       const port = await detectChromePort('main');
       if (!port) {
-        console.log('browser: not connected (main mode)');
-        console.log('请先开启 main browser 的远程调试，或改为 dedicated 模式。');
-        return null;
+        log('browser: not connected (main mode)');
+        return {
+          ok: false,
+          reason: 'main_not_connected',
+          availableModes: [],
+          requestedMode: 'main',
+          guidance: '请先开启 main browser 的远程调试，或改为 dedicated 模式。',
+        };
       }
-      return { browser: 'main', browserId: null, dedicatedProfileDir: null, port };
+      return {
+        ok: true,
+        browser: 'main',
+        browserId: null,
+        dedicatedProfileDir: null,
+        port,
+        availableModes: ['main'],
+        selectedBecause: 'requested_mode',
+      };
     }
 
     const dedicatedProfileDir = OPTIONS.dedicatedProfileDir || defaultDedicatedProfileDir(OPTIONS.browserId);
     const port = await detectChromePort('dedicated', dedicatedProfileDir);
     if (!port) {
-      console.log('browser: not connected (dedicated mode)');
-      console.log('请先启动专用浏览器，或检查 dedicated profile 路径是否正确：');
-      console.log(`  browserId: ${OPTIONS.browserId}`);
-      console.log(`  profile: ${dedicatedProfileDir}`);
-      return null;
+      log('browser: not connected (dedicated mode)');
+        return {
+          ok: false,
+          reason: 'dedicated_not_connected',
+        availableModes: [],
+        requestedMode: 'dedicated',
+        browserId: OPTIONS.browserId,
+        dedicatedProfileDir,
+        guidance: '请先启动专用浏览器，或检查 dedicated profile 路径是否正确。',
+      };
     }
-    return { browser: 'dedicated', browserId: OPTIONS.browserId, dedicatedProfileDir, port };
+    return {
+      ok: true,
+      browser: 'dedicated',
+      browserId: OPTIONS.browserId,
+      dedicatedProfileDir,
+      port,
+      availableModes: ['dedicated'],
+      selectedBecause: 'requested_mode',
+    };
   }
 
   const mainPort = await detectChromePort('main');
   const dedicated = await detectFirstDedicatedAvailable();
+  const availableModes = [];
+  if (mainPort) availableModes.push('main');
+  if (dedicated) availableModes.push('dedicated');
 
   if (mainPort && dedicated) {
-    console.log(`browser: both available (main + dedicated:${dedicated.browserId}) -> selected dedicated`);
-    return dedicated;
+    log(`browser: both available (main + dedicated:${dedicated.browserId}) -> selected dedicated`);
+    return {
+      ok: true,
+      ...dedicated,
+      availableModes,
+      selectedBecause: 'dedicated_preferred_when_both_available',
+    };
   }
   if (dedicated) {
-    console.log(`browser: dedicated available (${dedicated.browserId}) -> selected dedicated`);
-    return dedicated;
+    log(`browser: dedicated available (${dedicated.browserId}) -> selected dedicated`);
+    return {
+      ok: true,
+      ...dedicated,
+      availableModes,
+      selectedBecause: 'only_dedicated_available',
+    };
   }
   if (mainPort) {
-    console.log('browser: only main available -> selected main');
-    return { browser: 'main', browserId: null, dedicatedProfileDir: null, port: mainPort };
+    log('browser: only main available -> selected main');
+    return {
+      ok: true,
+      browser: 'main',
+      browserId: null,
+      dedicatedProfileDir: null,
+      port: mainPort,
+      availableModes,
+      selectedBecause: 'only_main_available',
+    };
   }
 
-  console.log('browser: none available');
-  console.log('请让用户选择浏览器模式后再继续：');
-  console.log('- 选主力浏览器：先在主力浏览器开启 remote debugging，然后重跑 check-deps。');
-  console.log('- 选专用浏览器：先启动 dedicated profile（带 --remote-debugging-port），再重跑 check-deps。');
-  return null;
+  log('browser: none available');
+  return {
+    ok: false,
+    reason: 'no_browser_available',
+    availableModes,
+    guidance: {
+      main: '先在主力浏览器开启 remote debugging，然后重跑 check-deps。',
+      dedicated: '先启动 dedicated profile（带 --remote-debugging-port），再重跑 check-deps。',
+    },
+  };
 }
 
 async function main() {
-  checkNode();
+  const node = checkNode();
 
   const runtime = await resolveRuntime();
-  if (!runtime) {
-    process.exit(1);
+  if (!runtime.ok) {
+    fail({
+      node,
+      proxyReady: false,
+      ...runtime,
+    });
   }
 
-  console.log(`browser: ok (port ${runtime.port}, ${runtime.browser} mode${runtime.browserId ? `, ${runtime.browserId}` : ''})`);
-
-  const proxyOk = await ensureProxy(runtime);
-  if (!proxyOk) {
-    process.exit(1);
+  log(`browser: ok (port ${runtime.port}, ${runtime.browser} mode${runtime.browserId ? `, ${runtime.browserId}` : ''})`);
+  const proxy = await ensureProxy(runtime);
+  if (!proxy.ok) {
+    fail({
+      node,
+      selectedMode: runtime.browser,
+      browserId: runtime.browserId,
+      dedicatedProfileDir: runtime.dedicatedProfileDir,
+      port: runtime.port,
+      availableModes: runtime.availableModes,
+      selectedBecause: runtime.selectedBecause,
+      proxyReady: false,
+      proxy,
+    });
   }
 
   const patternsDir = path.join(ROOT, 'references', 'site-patterns');
+  let sitePatterns = [];
   try {
-    const sites = fs.readdirSync(patternsDir)
+    sitePatterns = fs.readdirSync(patternsDir)
       .filter(f => f.endsWith('.md'))
       .map(f => f.replace(/\.md$/, ''));
-    if (sites.length) {
-      console.log(`\nsite-patterns: ${sites.join(', ')}`);
+    if (sitePatterns.length) {
+      log(`site-patterns: ${sitePatterns.join(', ')}`);
     }
   } catch {}
+
+  printJson({
+    ok: true,
+    node,
+    availableModes: runtime.availableModes,
+    selectedMode: runtime.browser,
+    selectedBecause: runtime.selectedBecause,
+    browserId: runtime.browserId,
+    dedicatedProfileDir: runtime.dedicatedProfileDir,
+    port: runtime.port,
+    proxyReady: true,
+    proxy,
+    sitePatterns,
+  });
 }
 
-await main();
+try {
+  await main();
+} catch (error) {
+  fail({
+    reason: 'unexpected_error',
+    message: error instanceof Error ? error.message : String(error),
+    proxyReady: false,
+  });
+}

--- a/scripts/find-url.mjs
+++ b/scripts/find-url.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// find-url - 从本地 Chrome 书签/历史中检索 URL
+// find-url - 从本地浏览器（Chrome）书签/历史中检索 URL
 // 用于定位公网搜索覆盖不到的目标（组织内部系统、SSO 后台、内网域名等）。
 //
 // 用法：
@@ -58,7 +58,7 @@ function parseSince(s) {
 function die(msg) { console.error(msg); process.exit(1); }
 function printUsage() { console.error(fs.readFileSync(new URL(import.meta.url)).toString().split('\n').slice(1, 19).map(l => l.replace(/^\/\/ ?/, '')).join('\n')); }
 
-// --- Chrome 用户数据目录（跨平台） ---------------------------------------
+// --- 浏览器（Chrome）用户数据目录（跨平台） ---------------------------------------
 function getChromeDataDir() {
   const home = os.homedir();
   switch (os.platform()) {
@@ -176,7 +176,7 @@ function printHistory(items, multiProfile, sortLabel) {
 const args = parseArgs(process.argv.slice(2));
 
 const dataDir = getChromeDataDir();
-if (!dataDir || !fs.existsSync(dataDir)) die('未找到 Chrome 用户数据目录');
+if (!dataDir || !fs.existsSync(dataDir)) die('未找到浏览器（Chrome）用户数据目录');
 
 const profiles = listProfiles(dataDir);
 const doBookmarks = args.only !== 'history';


### PR DESCRIPTION
本 PR 为 CDP 增加“专用浏览器”模式，并完善“主力浏览器 / 专用浏览器”双模式能力；同时支持在多种 Chromium 浏览器中按需选择。
主力浏览器：现有逻辑，复用登录态/插件/书签，方便日常调研
专用浏览器：使用独立浏览器profile，CDP链接不会触发浏览器调试确认弹窗，方便无人值守的agent使用场景
可以只使用其中一种模式，也可以两种都开通，告诉agent操作哪个浏览器。

  主要改动：

  1. 双模式能力

  - 支持 主力浏览器 与 专用浏览器 两种运行模式
  - 检查与连接流程按模式读取对应 profile 与调试端口
  - 健康检查输出模式信息，便于准确识别当前运行环境

  2. 支持选择任意 Chromium 浏览器

  - 支持通过 browser-id 选择不同 Chromium 浏览器实例
  - 支持常见 Chromium 系浏览器（如 Chrome、Chrome Canary、Chromium、
    Brave、Edge、Arc）
  - 专用浏览器模式可绑定独立 profile，便于长期复用与隔离

  3. 模式切换与运行一致性

  - 模式不一致时可进行代理重启与连接对齐
  - 减少“连错实例/连错 profile”导致的不确定行为
  - 与现有 tab 管理机制协同，提升长时任务可维护性

  4. 文档与提示统一

  - 明确主力浏览器/专用浏览器适用场景与取舍
  - 补充专用浏览器启动与检查方式
  - 统一术语与操作提示，降低理解与沟通成本