### PR TITLE
fix(cdp-proxy): block screenshot path traversal and header injection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-access",
   "description": "Complete web browsing and automation skill for Claude Code - intelligent tool selection, CDP browser automation, and site experience accumulation",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "author": {
     "name": "一泽 Eze"
   },

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -317,6 +317,14 @@ async function readBody(req) {
   return body;
 }
 
+// --- 写入路径白名单（防 /screenshot?file= 路径穿越） ---
+function isSafeWritePath(p) {
+  if (typeof p !== 'string' || !p) return false;
+  const resolved = path.resolve(p);
+  const roots = [os.tmpdir(), process.cwd()].map(r => path.resolve(r));
+  return roots.some(root => resolved === root || resolved.startsWith(root + path.sep));
+}
+
 // --- HTTP API ---
 const server = http.createServer(async (req, res) => {
   const parsed = new URL(req.url, `http://localhost:${PORT}`);
@@ -538,14 +546,21 @@ const server = http.createServer(async (req, res) => {
     // GET /screenshot?target=xxx&file=/tmp/x.png - 截图
     else if (pathname === '/screenshot') {
       const sid = await ensureSession(q.target);
-      const format = q.format || 'png';
+      const allowedFormats = new Set(['png', 'jpeg', 'webp']);
+      const format = allowedFormats.has(q.format) ? q.format : 'png';
       const resp = await sendCDP('Page.captureScreenshot', {
         format,
         quality: format === 'jpeg' ? 80 : undefined,
       }, sid);
       if (q.file) {
-        fs.writeFileSync(q.file, Buffer.from(resp.result.data, 'base64'));
-        res.end(JSON.stringify({ saved: q.file }));
+        if (!isSafeWritePath(q.file)) {
+          res.statusCode = 400;
+          res.end(JSON.stringify({ error: 'file 必须位于系统临时目录或当前工作目录下' }));
+          return;
+        }
+        const dst = path.resolve(q.file);
+        fs.writeFileSync(dst, Buffer.from(resp.result.data, 'base64'));
+        res.end(JSON.stringify({ saved: dst }));
       } else {
         res.setHeader('Content-Type', 'image/' + format);
         res.end(Buffer.from(resp.result.data, 'base64'));
@@ -607,7 +622,10 @@ async function main() {
         http.get(`http://127.0.0.1:${PORT}/health`, { timeout: 2000 }, (res) => {
           let d = '';
           res.on('data', c => d += c);
-          res.on('end', () => resolve(d.includes('"ok"')));
+          res.on('end', () => {
+            try { resolve(JSON.parse(d).status === 'ok'); }
+            catch { resolve(false); }
+          });
         }).on('error', () => resolve(false));
       });
       if (ok) {


### PR DESCRIPTION
## Summary
- `/screenshot?file=` 加路径白名单（仅允许 `os.tmpdir()` 与 `process.cwd()` 下），阻止任意路径写入（原实现 `fs.writeFileSync(q.file, ...)` 无校验，`file=../../etc/passwd` / `C:\Windows\...` 可越权写）
- `/screenshot?format=` 改为 `png/jpeg/webp` 显式白名单，防 `Content-Type: image/${format}` 响应头注入
- `main()` 检测已有实例时改用 `JSON.parse(d).status === 'ok'` 严格匹配（原 `d.includes('"ok"')` 子串过松，任何含 `"ok"` 字面量的 JSON 都会通过）
- `.claude-plugin/plugin.json` 版本对齐 SKILL.md（`2.4.2` → `2.5.0`）

`/eval`、`/setFiles` 等"按设计就强大"的端点不动 —— 它们是 skill 核心能力，且 proxy 仅绑 `127.0.0.1`。

## Test plan
- [x] `node --check scripts/cdp-proxy.mjs` 语法通过
- [x] `isSafeWritePath` 8 个用例：tmpdir / cwd 子路径放行；`/etc/passwd`、`C:\Windows\...`、`../../`、空串、`null` 全部拒绝
- [x] `node -e "require('./.claude-plugin/plugin.json').version"` 输出 `2.5.0`
- [ ] 手动：启动 proxy 后 `curl ".../screenshot?target=ID&file=../../etc/passwd"` 期望 400 + 错误说明
- [ ] 手动：启动 proxy 后 `curl ".../screenshot?target=ID&format=jpeg%0d%0aX:Y"` 期望响应头无注入

🤖 Generated with [Claude Code](https://claude.com/claude-code)