### PR TITLE
fix: findFallbackPort returns wsPath to fix CDP WebSocket connection

### DIFF
--- a/scripts/browser-discovery.mjs
+++ b/scripts/browser-discovery.mjs
@@ -130,9 +130,20 @@ export async function selectBrowser(override = null) {
 // 兜底：扫描常用固定端口
 // 适用场景：用户手动 --remote-debugging-port=9222 启动浏览器，
 // 此时 DevToolsActivePort 可能不在默认 user-data-dir。
+// 返回 { port, wsPath } 或 null（需 fetch wsPath 因为 Chrome 要求完整 UUID 路径）
 export async function findFallbackPort() {
   for (const port of [9222, 9229, 9333]) {
-    if (await checkPort(port)) return port;
+    if (!(await checkPort(port))) continue;
+    try {
+      const resp = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(3000) });
+      const data = await resp.json();
+      const wsUrl = data.webSocketDebuggerUrl;
+      if (wsUrl) {
+        const u = new URL(wsUrl);
+        return { port, wsPath: u.pathname };
+      }
+    } catch {}
+    return { port, wsPath: null };
   }
   return null;
 }

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -90,11 +90,11 @@ async function discoverChromePort() {
     );
   }
   // 仅在「从未成功连接 + 无偏好/override」时允许固定端口兜底（手动 --remote-debugging-port 启动场景）
-  const fallbackPort = await findFallbackPort();
-  if (fallbackPort !== null) {
+  const fallback = await findFallbackPort();
+  if (fallback !== null) {
     connectedBrowser = { id: 'unknown', label: '未知（通过手动调试端口连接）', source: 'fallback' };
-    console.log(`[CDP Proxy] 通过手动调试端口连接: ${fallbackPort}`);
-    return { port: fallbackPort, wsPath: null };
+    console.log(`[CDP Proxy] 通过手动调试端口连接: ${fallback.port}${fallback.wsPath ? '，带 wsPath' : ''}`);
+    return { port: fallback.port, wsPath: fallback.wsPath };
   }
   return null;
 }

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -165,9 +165,9 @@ async function resolveAndReport(override) {
 
     case 'empty': {
       // 末路兜底：尝试常见固定端口（用户手动 --remote-debugging-port=9222 启动的场景）
-      const fallbackPort = await findFallbackPort();
-      if (fallbackPort) {
-        console.log(`browser: ok (port ${fallbackPort}) [通过手动调试端口连接]`);
+      const fallback = await findFallbackPort();
+      if (fallback) {
+        console.log(`browser: ok (port ${fallback.port}) [通过手动调试端口连接]`);
         return { proceed: true };
       }
       console.log('browser: 未连接 — 没有任何浏览器打开远程调试开关');


### PR DESCRIPTION
## 问题

当 Chrome 通过 `--remote-debugging-port=9222` 启动时，`findFallbackPort()` 能检测到开放端口但只返回端口号。CDP Proxy 随后拼接 WebSocket URL 为 `ws://127.0.0.1:9222/devtools/browser`（缺少 UUID），Chrome 拒绝此连接。Chrome 要求从 `/json/version` 获取的完整路径（如 `/devtools/browser/<uuid>`）。

同时，新版 Chrome（148+）要求 `--remote-debugging-port` 必须配合 `--user-data-dir=<非默认目录>` 使用，这使得 DevToolsActivePort 不在 knownBrowsers() 检查的默认路径中，只能走 fallback 路径，从而使此 bug 必然触发。

## 修复

- **browser-discovery.mjs**: `findFallbackPort()` 现在 fetch `/json/version` 获取 `webSocketDebuggerUrl`，从中提取 wsPath，以 `{port, wsPath}` 结构返回
- **cdp-proxy.mjs**: 适配新的 `{port, wsPath}` 返回值，正确拼接 WebSocket URL
- **check-deps.mjs**: 适配新的返回值结构

## 测试

```
Node v26.0.0 + Chrome 148 + --remote-debugging-port=9222 --user-data-dir=<custom>
```

- CDP Proxy 成功连接 Chrome 调试端口
- `/health` 端点返回 `connected: true`
- `/targets`、`/new`、`/screenshot`、`/eval` 等端点正常
- 向后兼容：当 `/json/version` 不可用时返回 `{port, wsPath: null}`