### PR TITLE
Fix version skew, event-driven load detection, deduplicate API docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "web-access",
   "description": "Complete web browsing and automation skill for Claude Code - intelligent tool selection, CDP browser automation, and site experience accumulation",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "author": {
     "name": "一泽 Eze"
   },

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,43 +111,28 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 
 ### Proxy API
 
-所有操作通过 curl 调用 HTTP API：
+所有操作通过 curl 调用 `http://localhost:3456`。**完整 API 参考（含错误处理、/eval 使用提示）见 [`references/cdp-api.md`](references/cdp-api.md)。**
+
+快速参考：
 
 ```bash
-# 列出用户已打开的 tab
-curl -s http://localhost:3456/targets
-
-# 创建新后台 tab（自动等待加载）— URL 走 POST body，避免目标 URL 含 query 时被切分
-curl -s -X POST --data-raw 'https://example.com' http://localhost:3456/new
-
-# 页面信息
-curl -s "http://localhost:3456/info?target=ID"
-
-# 执行任意 JS：可读写 DOM、提取数据、操控元素、触发状态变更、提交表单、调用内部方法
-curl -s -X POST "http://localhost:3456/eval?target=ID" -d 'document.title'
-
-# 捕获页面渲染状态（含视频当前帧）
-curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"
-
-# 导航（URL 走 POST body，target 走 query）、后退
+# 创建新 tab（URL 走 POST body）                # 页面操作
+curl -s -X POST --data-raw 'https://example.com'  http://localhost:3456/new
 curl -s -X POST --data-raw 'https://example.com' "http://localhost:3456/navigate?target=ID"
-curl -s "http://localhost:3456/back?target=ID"
+curl -s "http://localhost:3456/info?target=ID"          # 页面信息
+curl -s "http://localhost:3456/back?target=ID"          # 后退
 
-# 点击（POST body 为 CSS 选择器）— JS el.click()，简单快速，覆盖大多数场景
-curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'
-
-# 真实鼠标点击 — CDP Input.dispatchMouseEvent，算用户手势，能触发文件对话框
+# 交互（body 为 CSS 选择器 / JS 表达式）          # 信息
+curl -s -X POST "http://localhost:3456/click?target=ID"   -d 'button.submit'
 curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
-
-# 文件上传 — 直接设置 file input 的本地文件路径，绕过文件对话框
+curl -s -X POST "http://localhost:3456/eval?target=ID"    -d 'document.title'
 curl -s -X POST "http://localhost:3456/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'
 
-# 滚动（触发懒加载）
-curl -s "http://localhost:3456/scroll?target=ID&y=3000"
+# 滚动与截图                                      # 管理
 curl -s "http://localhost:3456/scroll?target=ID&direction=bottom"
-
-# 关闭 tab
-curl -s "http://localhost:3456/close?target=ID"
+curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"
+curl -s http://localhost:3456/targets                  # 列出所有 tab
+curl -s "http://localhost:3456/close?target=ID"        # 关闭 tab
 ```
 
 ### 页面内导航

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -161,6 +161,16 @@ async function connect() {
       const data = typeof evt === 'string' ? evt : (evt.data || evt);
       const msg = JSON.parse(typeof data === 'string' ? data : data.toString());
 
+      // 路由无 id 的 CDP 事件到注册的监听器
+      if (!msg.id) {
+        const listeners = eventListeners.get(msg.method);
+        if (listeners) {
+          for (const cb of listeners) {
+            try { cb(msg); } catch { /* 监听器错误不影响其他 */ }
+          }
+        }
+      }
+
       if (msg.method === 'Target.attachedToTarget') {
         const { sessionId, targetInfo } = msg.params;
         sessions.set(targetInfo.targetId, sessionId);
@@ -275,9 +285,22 @@ async function closeAllManagedTabs() {
   if (targets.length) console.log(`[CDP Proxy] Shutdown: closed ${targets.length} managed tab(s)`);
 }
 
-// --- 等待页面加载 ---
+// --- CDP 事件监听（用于接收非请求的浏览器事件）---
+const eventListeners = new Map(); // method -> Set<callback>
+
+function addEventListener(method, callback) {
+  if (!eventListeners.has(method)) eventListeners.set(method, new Set());
+  eventListeners.get(method).add(callback);
+  // 返回取消订阅函数
+  return () => {
+    const set = eventListeners.get(method);
+    if (set) set.delete(callback);
+  };
+}
+
+// --- 等待页面加载（事件驱动，零轮询）---
 async function waitForLoad(sessionId, timeoutMs = 15000) {
-  // 启用 Page 域
+  // 启用 Page 域以接收 loadEventFired 事件
   await sendCDP('Page.enable', {}, sessionId);
 
   return new Promise((resolve) => {
@@ -286,22 +309,28 @@ async function waitForLoad(sessionId, timeoutMs = 15000) {
       if (resolved) return;
       resolved = true;
       clearTimeout(timer);
-      clearInterval(checkInterval);
+      unsubscribe();
       resolve(result);
     };
 
     const timer = setTimeout(() => done('timeout'), timeoutMs);
-    const checkInterval = setInterval(async () => {
-      try {
-        const resp = await sendCDP('Runtime.evaluate', {
-          expression: 'document.readyState',
-          returnByValue: true,
-        }, sessionId);
-        if (resp.result?.result?.value === 'complete') {
-          done('complete');
-        }
-      } catch { /* 忽略 */ }
-    }, 500);
+
+    // 使用 Page.loadEventFired 事件替代轮询（零开销，即时响应）
+    const unsubscribe = addEventListener('Page.loadEventFired', (msg) => {
+      if (msg.sessionId === sessionId) {
+        done('complete');
+      }
+    });
+
+    // 如果页面已经加载完毕（导航到已缓存的页面），立刻检测一次
+    sendCDP('Runtime.evaluate', {
+      expression: 'document.readyState',
+      returnByValue: true,
+    }, sessionId).then(resp => {
+      if (resp.result?.result?.value === 'complete' && !resolved) {
+        done('complete');
+      }
+    }).catch(() => {});
   });
 }
 


### PR DESCRIPTION
## Summary

Three targeted fixes for the web-access skill.

### 1. Fix plugin.json version (2.5.2 → 2.5.3)
`plugin.json` and `SKILL.md` disagreed on version. This matters because v2.5.3 introduced breaking changes (`/new` and `/navigate` switched from GET to POST).

### 2. Event-driven page load detection
**Before**: `waitForLoad()` polled `document.readyState` via `Runtime.evaluate` every 500ms.
**After**: Subscribes to `Page.loadEventFired` CDP event (zero polling, instant response) with a one-shot `Runtime.evaluate` fallback for already-loaded cached pages.

Also adds a general `eventListeners` Map + `addEventListener()` for routing unsolicited CDP events — reusable by other proxy features.

### 3. Deduplicate API documentation
`SKILL.md` had a full 13-endpoint curl listing duplicating `references/cdp-api.md`. Replaced with compact quick-reference table and explicit delegation to `cdp-api.md`.

### Files changed
- `.claude-plugin/plugin.json`
- `SKILL.md`
- `scripts/cdp-proxy.mjs`