### PR TITLE
feat: support WSL2 environment in find-url

### DIFF
--- a/scripts/find-url.mjs
+++ b/scripts/find-url.mjs
@@ -66,6 +66,30 @@ function printUsage() { console.error(fs.readFileSync(new URL(import.meta.url)).
 function knownBrowserDataDirs() {
   const home = os.homedir();
   const localAppData = process.env.LOCALAPPDATA || '';
+  const isWSL2 = os.platform() === 'linux' && fs.existsSync('/mnt/c/Users');
+
+  if (isWSL2) {
+    // WSL2: 扫描 /mnt/c/Users/*/AppData/Local/ 下的浏览器数据
+    const results = [];
+    try {
+      const users = fs.readdirSync('/mnt/c/Users').filter(u =>
+        !u.startsWith('.') && !['All Users', 'Default', 'Default User', 'Public', 'desktop.ini'].includes(u)
+      );
+      for (const user of users) {
+        const base = `/mnt/c/Users/${user}/AppData/Local`;
+        const candidates = [
+          { id: 'chrome', label: `Chrome (${user})`, dir: `${base}/Google/Chrome/User Data` },
+          { id: 'edge',   label: `Edge (${user})`,   dir: `${base}/Microsoft/Edge/User Data` },
+        ];
+        for (const c of candidates) {
+          if (fs.existsSync(c.dir)) results.push(c);
+        }
+      }
+    } catch { /* 权限不足等情况静默跳过 */ }
+    if (results.length) return results;
+    // 回退到标准 Linux 路径
+  }
+
   switch (os.platform()) {
     case 'darwin':
       return [


### PR DESCRIPTION
## What

`find-url.mjs` 在 WSL2 下能自动发现 Windows 侧的 Chrome/Edge 数据目录。

## Why

WSL2 用户的浏览器运行在 Windows 端，数据在 `/mnt/c/Users/<user>/AppData/Local/`，原脚本只查 `~/.config/`
导致完全找不到书签和历史。

## How

在 `knownBrowserDataDirs()` 开头加 WSL2 检测（`/mnt/c/Users` 存在性），扫描该路径下的 Chrome/Edge 数据目录，找到则直接返回，否则回退到标准 Linux 路径。

- 跳过系统用户（`.xxx`、`All Users`、`Default` 等）
- 标签带用户名：`Chrome (xiuerhuahuazi)` / `Edge (xiuerhuahuazi)`
- 权限不足等异常静默跳过，不影响后续逻辑

## Scope

仅改 `scripts/find-url.mjs` 的 `knownBrowserDataDirs` 函数，其他逻辑不变。

<img width="797" height="479" alt="bb687b655943856fe78e2640198c62bc" src="https://github.com/user-attachments/assets/cab86c22-ae1e-4964-a67b-78c226253a24" />
<img width="781" height="381" alt="微信图片_2026-06-02_162619_460" src="https://github.com/user-attachments/assets/54f87be9-6146-448f-80b1-e4af2f7309ea" />