### PR TITLE
fix(proxy): detect stale proxy after browser restart + surface /navigate errors

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -399,7 +399,14 @@ const server = http.createServer(async (req, res) => {
       // 等待页面加载完成
       await waitForLoad(sid);
 
-      res.end(JSON.stringify(resp.result));
+      // 显式透出导航错误：浏览器重启导致僵尸会话时 Page.navigate 会返回 {error}（无 result），
+      // 直接 JSON.stringify(resp.result) 会写出空 body，调用方无从判断。这里把错误透出来。
+      if (resp.error) {
+        res.statusCode = 502;
+        res.end(JSON.stringify({ error: 'Page.navigate failed', cdp: resp.error }));
+        return;
+      }
+      res.end(JSON.stringify(resp.result ?? { error: 'empty navigation result' }));
     }
 
     // GET /back?target=xxx - 后退

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -8,7 +8,7 @@
 // 持久偏好 → config.env (skill 根目录, gitignored)
 // 单次覆盖 → --browser 命令行参数（全链路 argv，不碰 process.env）
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -75,9 +75,27 @@ function startProxyDetached(browserOverride) {
   fs.closeSync(logFd);
 }
 
+// 功能性探针：health/targets 正常不等于会话可用。浏览器若在 proxy 运行期间重启过，
+// 旧 proxy 的会话会失效——所有 Page.navigate 静默失败、tab 卡在 about:blank，但 /health 仍报 ok。
+// 建一个 about:blank 测试 tab → eval → close，全过才算真健康。
+async function functionalProbe(baseUrl) {
+  try {
+    const newRes = await fetch(`${baseUrl}/new`, { method: 'POST', body: 'about:blank', signal: AbortSignal.timeout(5000) });
+    const { targetId } = await newRes.json();
+    if (!targetId) return false;
+    const evalRes = await fetch(`${baseUrl}/eval?target=${targetId}`, { method: 'POST', body: '1+1', signal: AbortSignal.timeout(5000) });
+    const evalJson = await evalRes.json();
+    await fetch(`${baseUrl}/close?target=${targetId}`, { signal: AbortSignal.timeout(5000) }).catch(() => {});
+    return evalJson?.value === 2;
+  } catch {
+    return false;
+  }
+}
+
 async function ensureProxy(expectedBrowserId, browserOverride) {
-  const healthUrl = `http://127.0.0.1:${PROXY_PORT}/health`;
-  const targetsUrl = `http://127.0.0.1:${PROXY_PORT}/targets`;
+  const baseUrl = `http://127.0.0.1:${PROXY_PORT}`;
+  const healthUrl = `${baseUrl}/health`;
+  const targetsUrl = `${baseUrl}/targets`;
 
   // 复用：proxy 已运行 + 已连接浏览器 → 校验 expected vs actual
   const health = await httpGetJson(healthUrl);
@@ -89,8 +107,17 @@ async function ensureProxy(expectedBrowserId, browserOverride) {
       console.log('  请在终端运行 pkill -f cdp-proxy.mjs 重置后再试');
       return false;
     }
-    console.log(`proxy: ready (${runningLabel})`);
-    return true;
+    // 健康但未必能用：实测一遍 new/eval/close 是否真的工作；失败则判定为僵尸 proxy
+    // （浏览器重启后遗留的旧进程，会话失效），杀掉后走下方重启分支。
+    const probeOk = await functionalProbe(baseUrl);
+    if (probeOk) {
+      console.log(`proxy: ready (${runningLabel})`);
+      return true;
+    }
+    console.log(`proxy: stale — 健康检查通过但功能性探针失败（浏览器可能已重启），杀掉旧 proxy 重启...`);
+    try { spawnSync('pkill', ['-f', 'cdp-proxy.mjs']); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    // 落入下方 startProxyDetached 重启分支
   }
 
   console.log('proxy: connecting...');


### PR DESCRIPTION
## Problem

When Chrome/Edge is **restarted while a `cdp-proxy` process is already running** (very common — users quit/relaunch their browser all the time), the leftover proxy keeps answering `/health` with `connected: true`, but its page-level sessions are now dead. The result:

- `Page.navigate` silently fails for every call
- tabs get stuck on `about:blank`
- `/navigate` returns an **empty response body** (`JSON.stringify(undefined)`), so the agent calling it has no signal to act on

From the outside this looks like *"CDP can do nothing / every web task fails"* and it persists for as long as the stale proxy survives.

Root cause: `check-deps` reuses **any** proxy that answers `/health`, never verifying that sessions actually work.

## Repro

```bash
# 1. Chrome with remote debugging, start the proxy
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 &
node scripts/check-deps.mjs          # -> "proxy: ready (Chrome)"

# 2. quit & relaunch Chrome (new PID, same port 9222)

# 3. check again — health still ok, but the proxy is now brain-dead
node scripts/check-deps.mjs          # -> "proxy: ready (Chrome)"  (false positive!)
# /new <url>          -> tab stuck on about:blank
# /navigate <url>     -> ""  (empty body, navigation silently failed)
```

## Fix

**1. `check-deps.mjs` — functional probe in the reuse branch**

Before reusing a healthy-looking proxy, run a real `new → eval → close` round-trip on a throwaway `about:blank` tab. If it fails, the proxy is stale → `pkill -f cdp-proxy.mjs` and restart it (the same manual fix the SKILL.md already tells users to do). This makes a browser restart self-healing instead of silently breaking everything.

**2. `cdp-proxy.mjs` — `/navigate` surfaces errors**

When `Page.navigate` returns a CDP `{error}` (or no `result`), return HTTP 502 + the error JSON instead of writing an empty body. Turns an invisible failure into a diagnosable one.

Both changes are minimal and additive (happy path behavior is unchanged — verified: navigate still returns full results, the probe passes on a healthy proxy without spurious restarts and leaves `managedTabs` at 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
