### PR TITLE
feat: 新增 /emulate 端点支持设备/移动视口模拟

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -584,6 +584,35 @@ const server = http.createServer(async (req, res) => {
       res.end(resp.result?.result?.value || '{}');
     }
 
+    // POST /emulate?target=xxx (body=JSON) - 设备/移动视口模拟；?reset=1 清除
+    // body: {"width":390,"height":844,"dsf":2,"mobile":true,"ua":"...iPhone..."}
+    // 状态作用于该 target 的 session：emulate 后其 /eval /screenshot /click 均保持该视口，
+    // 直到 reset 或 /close。建议只对自建临时 tab 使用。
+    else if (pathname === '/emulate') {
+      const sid = await ensureSession(q.target);
+      if (q.reset === '1' || q.reset === 'true') {
+        await sendCDP('Emulation.clearDeviceMetricsOverride', {}, sid);
+        await sendCDP('Emulation.setTouchEmulationEnabled', { enabled: false }, sid);
+        await sendCDP('Emulation.setUserAgentOverride', { userAgent: '' }, sid);
+        res.end(JSON.stringify({ reset: true }));
+      } else {
+        let opts = {};
+        const body = (await readBody(req)).trim();
+        if (body) {
+          try { opts = JSON.parse(body); }
+          catch { res.statusCode = 400; res.end(JSON.stringify({ error: 'body 需为 JSON' })); return; }
+        }
+        const width = opts.width || 390;
+        const height = opts.height || 844;
+        const deviceScaleFactor = opts.dsf ?? opts.deviceScaleFactor ?? 2;
+        const mobile = opts.mobile ?? true;
+        await sendCDP('Emulation.setDeviceMetricsOverride', { width, height, deviceScaleFactor, mobile }, sid);
+        await sendCDP('Emulation.setTouchEmulationEnabled', { enabled: !!mobile }, sid);
+        if (opts.ua) await sendCDP('Emulation.setUserAgentOverride', { userAgent: opts.ua }, sid);
+        res.end(JSON.stringify({ emulated: { width, height, deviceScaleFactor, mobile, ua: !!opts.ua } }));
+      }
+    }
+
     else {
       res.statusCode = 404;
       res.end(JSON.stringify({
@@ -600,6 +629,7 @@ const server = http.createServer(async (req, res) => {
           '/click?target=': 'POST body=CSS选择器 - 点击元素',
           '/scroll?target=&y=&direction=': 'GET - 滚动页面',
           '/screenshot?target=&file=': 'GET - 截图',
+          '/emulate?target=&reset=': 'POST body=JSON{width,height,dsf,mobile,ua} - 设备/移动视口模拟；reset=1 清除',
         },
       }));
     }


### PR DESCRIPTION
## 背景

用 web-access 验证**移动端 UI**时，CDP proxy 没有视口模拟能力：`/screenshot` 截的是当前窗口尺寸，靠 `matchMedia('(max-width: 768px)')` 触发的 mobile-only 样式在桌面窗口下根本测不到。目前只能绕过 proxy、自己连 `ws://…/devtools/browser` + `Target.attachToTarget` + `Emulation.setDeviceMetricsOverride` 手写一段 CDP 脚本，每次移动端验证都要重写。

## 改动

CDP proxy 新增一个端点（纯增量路由，不碰任何现有端点）：

```
POST /emulate?target=ID   body: {"width":390,"height":844,"dsf":2,"mobile":true,"ua":"...iPhone..."}
  → Emulation.setDeviceMetricsOverride + setTouchEmulationEnabled + setUserAgentOverride
POST /emulate?target=ID&reset=1   → 清除以上覆盖
```

字段均可选，默认 `390x844 / dsf 2 / mobile true`。

移动端验证从「手写 30 行 CDP 脚本」变成一行 `curl`，之后该 tab 的 `/eval`、`/click`、`/screenshot` 都自动在移动视口下进行。

## 行为与边界

- override 是 **session 级有状态**：emulate 后该 target 一直保持该视口，直到 `reset` 或 `/close`（关闭 tab 时 session 连 override 一并销毁）。建议只对自建临时 tab 使用。
- 不调 `/emulate` 时行为零变化；proxy 原本没有任何 `Emulation.*` 调用，无冲突。

## 测试

端到端验证（带 `width=device-width` 的页面，等价真实 SSR 站点）：

| 检查 | 结果 |
|---|---|
| `innerWidth` | 390 ✓ |
| `matchMedia('(max-width: 768px)')` | true ✓ |
| `screen.width` | 390 ✓ |
| `devicePixelRatio` | ≈2 ✓ |
| UA 覆盖 | 生效 ✓ |
| `reset=1` 后 innerWidth / dpr | 还原 ✓ |

`node --check` 通过。