### PR TITLE
fix: harden macOS Chrome CDP detection and wait flow

### DIFF
--- a/scripts/browser-discovery.mjs
+++ b/scripts/browser-discovery.mjs
@@ -59,6 +59,26 @@ export function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
   });
 }
 
+async function checkDebuggerWebSocket(port, wsPath, host = '127.0.0.1', timeoutMs = 3000) {
+  if (!wsPath) return false;
+  return new Promise((resolve) => {
+    const ws = new WebSocket(`ws://${host}:${port}${wsPath}`);
+    const timer = setTimeout(() => {
+      try { ws.close(); } catch {}
+      resolve(false);
+    }, timeoutMs);
+    ws.addEventListener('open', () => {
+      clearTimeout(timer);
+      try { ws.close(); } catch {}
+      resolve(true);
+    });
+    ws.addEventListener('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
 // DevTools 元数据检测
 // 仅端口可连并不代表它真的是 Chrome DevTools 端点；
 // 需要进一步确认 /json/version 返回了可用的 webSocketDebuggerUrl。
@@ -126,7 +146,8 @@ async function detectAll() {
     const wsPath = lines[1] || null;
     if (!(port > 0 && port < 65536)) continue;
     if (!(await checkPort(port))) continue;
-    if (!(await checkDevToolsEndpoint(port, wsPath))) continue;
+    if (!(await checkDevToolsEndpoint(port, wsPath)) &&
+        !(await checkDebuggerWebSocket(port, wsPath))) continue;
     result.push({ ...browser, port, wsPath });
   }
   return result;

--- a/scripts/browser-discovery.mjs
+++ b/scripts/browser-discovery.mjs
@@ -59,6 +59,42 @@ export function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
   });
 }
 
+// DevTools 元数据检测
+// 仅端口可连并不代表它真的是 Chrome DevTools 端点；
+// 需要进一步确认 /json/version 返回了可用的 webSocketDebuggerUrl。
+async function checkDevToolsEndpoint(port, expectedWsPath = null, host = '127.0.0.1', timeoutMs = 3000) {
+  try {
+    const res = await fetch(`http://${host}:${port}/json/version`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return false;
+    const data = await res.json();
+    if (!data?.webSocketDebuggerUrl) return false;
+    if (expectedWsPath && !String(data.webSocketDebuggerUrl).endsWith(expectedWsPath)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getDevToolsMetadata(port, host = '127.0.0.1', timeoutMs = 3000) {
+  try {
+    const res = await fetch(`http://${host}:${port}/json/version`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data?.webSocketDebuggerUrl) return null;
+    const prefix = `ws://${host}:${port}`;
+    const wsPath = String(data.webSocketDebuggerUrl).startsWith(prefix)
+      ? String(data.webSocketDebuggerUrl).slice(prefix.length)
+      : null;
+    return { port, wsPath, webSocketDebuggerUrl: data.webSocketDebuggerUrl };
+  } catch {
+    return null;
+  }
+}
+
 // 读 config.env 文件（不写入 process.env，分清来源）
 // 格式：KEY=VALUE，# 开头是注释
 function readConfig() {
@@ -87,9 +123,11 @@ async function detectAll() {
     catch { continue; }
     const lines = content.trim().split(/\r?\n/).filter(Boolean);
     const port = parseInt(lines[0], 10);
+    const wsPath = lines[1] || null;
     if (!(port > 0 && port < 65536)) continue;
     if (!(await checkPort(port))) continue;
-    result.push({ ...browser, port, wsPath: lines[1] || null });
+    if (!(await checkDevToolsEndpoint(port, wsPath))) continue;
+    result.push({ ...browser, port, wsPath });
   }
   return result;
 }
@@ -132,7 +170,17 @@ export async function selectBrowser(override = null) {
 // 此时 DevToolsActivePort 可能不在默认 user-data-dir。
 export async function findFallbackPort() {
   for (const port of [9222, 9229, 9333]) {
-    if (await checkPort(port)) return port;
+    if (!(await checkPort(port))) continue;
+    if (await checkDevToolsEndpoint(port)) return port;
+  }
+  return null;
+}
+
+export async function findFallbackDebugger() {
+  for (const port of [9222, 9229, 9333]) {
+    if (!(await checkPort(port))) continue;
+    const metadata = await getDevToolsMetadata(port);
+    if (metadata) return metadata;
   }
   return null;
 }

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
-import { selectBrowser, findFallbackPort } from './browser-discovery.mjs';
+import { selectBrowser, findFallbackDebugger } from './browser-discovery.mjs';
 
 // --- 解析命令行 --browser 参数（本次启动用哪个浏览器）---
 function parseBrowserArg() {
@@ -90,11 +90,11 @@ async function discoverChromePort() {
     );
   }
   // 仅在「从未成功连接 + 无偏好/override」时允许固定端口兜底（手动 --remote-debugging-port 启动场景）
-  const fallbackPort = await findFallbackPort();
-  if (fallbackPort !== null) {
+  const fallback = await findFallbackDebugger();
+  if (fallback !== null) {
     connectedBrowser = { id: 'unknown', label: '未知（通过手动调试端口连接）', source: 'fallback' };
-    console.log(`[CDP Proxy] 通过手动调试端口连接: ${fallbackPort}`);
-    return { port: fallbackPort, wsPath: null };
+    console.log(`[CDP Proxy] 通过手动调试端口连接: ${fallback.port}${fallback.wsPath ? '，带 wsPath' : ''}`);
+    return { port: fallback.port, wsPath: fallback.wsPath };
   }
   return null;
 }

--- a/scripts/check-deps-helpers.mjs
+++ b/scripts/check-deps-helpers.mjs
@@ -1,0 +1,18 @@
+export async function waitForProxyConnection({
+  healthUrl,
+  attempts = 15,
+  timeoutMs = 8000,
+  httpGetJson,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
+  for (let i = 1; i <= attempts; i++) {
+    const health = await httpGetJson(healthUrl, timeoutMs);
+    if (health?.status === 'ok' && health.connected) {
+      return true;
+    }
+    if (i < attempts) {
+      await sleep(1000);
+    }
+  }
+  return false;
+}

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -14,6 +14,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { selectBrowser, knownBrowsers, findFallbackPort } from './browser-discovery.mjs';
+import { waitForProxyConnection } from './check-deps-helpers.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PROXY_SCRIPT = path.join(ROOT, 'scripts', 'cdp-proxy.mjs');
@@ -77,7 +78,6 @@ function startProxyDetached(browserOverride) {
 
 async function ensureProxy(expectedBrowserId, browserOverride) {
   const healthUrl = `http://127.0.0.1:${PROXY_PORT}/health`;
-  const targetsUrl = `http://127.0.0.1:${PROXY_PORT}/targets`;
 
   // 复用：proxy 已运行 + 已连接浏览器 → 校验 expected vs actual
   const health = await httpGetJson(healthUrl);
@@ -98,18 +98,16 @@ async function ensureProxy(expectedBrowserId, browserOverride) {
 
   await new Promise((r) => setTimeout(r, 2000));
 
-  for (let i = 1; i <= 15; i++) {
-    const result = await httpGetJson(targetsUrl, 8000);
-    if (Array.isArray(result)) {
-      const newHealth = await httpGetJson(healthUrl);
-      const label = newHealth?.browser?.label || 'unknown';
-      console.log(`proxy: ready (${label})`);
-      return true;
-    }
-    if (i === 1) {
-      console.log('⚠️  浏览器可能有授权弹窗，请点击「允许」后等待连接...');
-    }
-    await new Promise((r) => setTimeout(r, 1000));
+  console.log('⚠️  浏览器可能有授权弹窗，请点击「允许」后等待连接...');
+  const ready = await waitForProxyConnection({
+    healthUrl,
+    httpGetJson,
+  });
+  if (ready) {
+    const newHealth = await httpGetJson(healthUrl);
+    const label = newHealth?.browser?.label || 'unknown';
+    console.log(`proxy: ready (${label})`);
+    return true;
   }
 
   console.log('❌ 连接超时，请检查浏览器调试设置');

--- a/tests/check-deps-wait.test.mjs
+++ b/tests/check-deps-wait.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { waitForProxyConnection } from '../scripts/check-deps-helpers.mjs';
+
+test('waitForProxyConnection polls health until proxy reports connected', async () => {
+  const calls = [];
+  const healthUrl = 'http://127.0.0.1:3456/health';
+  const responses = [
+    { status: 'ok', connected: false },
+    { status: 'ok', connected: false },
+    { status: 'ok', connected: true, browser: { label: 'Chrome' } },
+  ];
+
+  const ready = await waitForProxyConnection({
+    healthUrl,
+    attempts: responses.length,
+    httpGetJson: async (url) => {
+      calls.push(url);
+      return responses.shift() ?? null;
+    },
+    sleep: async () => {},
+  });
+
+  assert.equal(ready, true);
+  assert.deepEqual(calls, [healthUrl, healthUrl, healthUrl]);
+});
+
+test('waitForProxyConnection returns false after exhausting health polls', async () => {
+  const healthUrl = 'http://127.0.0.1:3456/health';
+
+  const ready = await waitForProxyConnection({
+    healthUrl,
+    attempts: 2,
+    httpGetJson: async () => ({ status: 'ok', connected: false }),
+    sleep: async () => {},
+  });
+
+  assert.equal(ready, false);
+});


### PR DESCRIPTION
## 中文

### 背景

我们在 macOS 上调用 `web-access` 时遇到了一点问题。主 Chrome 的远程调试授权是异步完成的，但 `check-deps.mjs` 在等待 proxy 就绪时会反复请求 `/targets`，而 `/targets` 会触发 `cdp-proxy.mjs` 再次调用 `connect()`。

在我们的复现场景里：

- Chrome 的 `DevToolsActivePort` 文件里写的是 `9222`
- `check-deps.mjs --browser chrome` 能识别主 Chrome
- 但用户还没来得及完成授权时，等待循环已经多次打到 `/targets`
- 结果是浏览器会收到一串重复的远程调试授权请求，体验很差

主 Chrome 本身并不是完全不可用。问题主要出在等待阶段的轮询目标选错了：为了判断 proxy 是否 ready，只需要看 `/health` 是否已经 `connected`，没必要在等待时不断访问会触发重连的 `/targets`。

### 修改内容

- 把 `check-deps.mjs` 中等待 proxy 就绪的逻辑提取成单独 helper
- 等待阶段只轮询 `/health`
- 只有 `/health.connected === true` 时才判定 proxy 已 ready，不再用 `/targets` 作为“探活”手段

### 复现结果

修复前：

```text
[CDP Proxy] 运行在 http://localhost:3456
[CDP Proxy] 选用 Chrome (端口 9222，带 wsPath) [--browser 指定]
[CDP Proxy] 连接错误: 连接失败 （端口缓存已清除，下次将重新发现）
[CDP Proxy] 连接断开
...上面的连接错误会因为 /targets 轮询而反复出现
```

修复后：

```text
node: ok (v25.9.0)
browser: ok (Chrome, port 9222) [--browser 指定]
proxy: connecting...
⚠️  浏览器可能有授权弹窗，请点击「允许」后等待连接...
❌ 连接超时，请检查浏览器调试设置
```

### Test Plan

- [x] 在 macOS 上复现主 Chrome 授权等待期间的重复连接请求
- [x] 新增单元测试，验证等待逻辑只轮询 `/health`
- [x] 运行 `node --test tests/check-deps-wait.test.mjs`
- [x] 本地验证超时时的 proxy 日志只保留一次启动/选用浏览器记录，不再因为等待循环刷出多次连接尝试

---

## English

### Background

We hit an issue when using `web-access` on macOS. Chrome authorization for remote debugging is asynchronous, but `check-deps.mjs` currently waits for readiness by polling `/targets`, and `/targets` triggers `cdp-proxy.mjs` to call `connect()` again.

In our repro:

- Chrome wrote `9222` into `DevToolsActivePort`
- `check-deps.mjs --browser chrome` correctly selected the main Chrome instance
- but before the user finished approving the connection, the wait loop kept hitting `/targets`
- that caused a burst of repeated remote-debugging authorization requests in Chrome

The main Chrome instance itself was not fundamentally broken. The noisy behavior came from using the wrong readiness probe during the wait phase. To know whether the proxy is ready, it is enough to poll `/health` and wait for `connected === true`; polling `/targets` during that phase is unnecessary and can re-trigger connection attempts.

### Changes

- extract proxy wait logic in `check-deps.mjs` into a small helper
- poll only `/health` while waiting for readiness
- consider the proxy ready only when `/health.connected === true`, instead of using `/targets` as a liveness probe

### Repro result

Before:

```text
[CDP Proxy] 运行在 http://localhost:3456
[CDP Proxy] 选用 Chrome (端口 9222，带 wsPath) [--browser 指定]
[CDP Proxy] 连接错误: 连接失败 （端口缓存已清除，下次将重新发现）
[CDP Proxy] 连接断开
...the same connection attempt could be re-triggered repeatedly by /targets polling
```

After:

```text
node: ok (v25.9.0)
browser: ok (Chrome, port 9222) [--browser 指定]
proxy: connecting...
⚠️  浏览器可能有授权弹窗，请点击「允许」后等待连接...
❌ 连接超时，请检查浏览器调试设置
```

### Test Plan

- [x] reproduce repeated connection attempts while waiting for Chrome authorization on macOS
- [x] add a unit test asserting the wait loop polls `/health` only
- [x] run `node --test tests/check-deps-wait.test.mjs`
- [x] verify locally that a timeout leaves only a single startup/selection record in the proxy log instead of repeated connect spam
