### PR TITLE
fix: poll health while waiting for proxy readiness

### DIFF
--- a/scripts/check-deps-helpers.mjs
+++ b/scripts/check-deps-helpers.mjs
@@ -1,0 +1,18 @@
+export async function waitForProxyConnection({
+  healthUrl,
+  attempts = 15,
+  timeoutMs = 8000,
+  httpGetJson,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
+  for (let i = 1; i <= attempts; i++) {
+    const health = await httpGetJson(healthUrl, timeoutMs);
+    if (health?.status === 'ok' && health.connected) {
+      return true;
+    }
+    if (i < attempts) {
+      await sleep(1000);
+    }
+  }
+  return false;
+}

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -14,6 +14,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { selectBrowser, knownBrowsers, findFallbackPort } from './browser-discovery.mjs';
+import { waitForProxyConnection } from './check-deps-helpers.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PROXY_SCRIPT = path.join(ROOT, 'scripts', 'cdp-proxy.mjs');
@@ -77,7 +78,6 @@ function startProxyDetached(browserOverride) {
 
 async function ensureProxy(expectedBrowserId, browserOverride) {
   const healthUrl = `http://127.0.0.1:${PROXY_PORT}/health`;
-  const targetsUrl = `http://127.0.0.1:${PROXY_PORT}/targets`;
 
   // 复用：proxy 已运行 + 已连接浏览器 → 校验 expected vs actual
   const health = await httpGetJson(healthUrl);
@@ -98,18 +98,16 @@ async function ensureProxy(expectedBrowserId, browserOverride) {
 
   await new Promise((r) => setTimeout(r, 2000));
 
-  for (let i = 1; i <= 15; i++) {
-    const result = await httpGetJson(targetsUrl, 8000);
-    if (Array.isArray(result)) {
-      const newHealth = await httpGetJson(healthUrl);
-      const label = newHealth?.browser?.label || 'unknown';
-      console.log(`proxy: ready (${label})`);
-      return true;
-    }
-    if (i === 1) {
-      console.log('⚠️  浏览器可能有授权弹窗，请点击「允许」后等待连接...');
-    }
-    await new Promise((r) => setTimeout(r, 1000));
+  console.log('⚠️  浏览器可能有授权弹窗，请点击「允许」后等待连接...');
+  const ready = await waitForProxyConnection({
+    healthUrl,
+    httpGetJson,
+  });
+  if (ready) {
+    const newHealth = await httpGetJson(healthUrl);
+    const label = newHealth?.browser?.label || 'unknown';
+    console.log(`proxy: ready (${label})`);
+    return true;
   }
 
   console.log('❌ 连接超时，请检查浏览器调试设置');

--- a/tests/check-deps-wait.test.mjs
+++ b/tests/check-deps-wait.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { waitForProxyConnection } from '../scripts/check-deps-helpers.mjs';
+
+test('waitForProxyConnection polls health until proxy reports connected', async () => {
+  const calls = [];
+  const healthUrl = 'http://127.0.0.1:3456/health';
+  const responses = [
+    { status: 'ok', connected: false },
+    { status: 'ok', connected: false },
+    { status: 'ok', connected: true, browser: { label: 'Chrome' } },
+  ];
+
+  const ready = await waitForProxyConnection({
+    healthUrl,
+    attempts: responses.length,
+    httpGetJson: async (url) => {
+      calls.push(url);
+      return responses.shift() ?? null;
+    },
+    sleep: async () => {},
+  });
+
+  assert.equal(ready, true);
+  assert.deepEqual(calls, [healthUrl, healthUrl, healthUrl]);
+});
+
+test('waitForProxyConnection returns false after exhausting health polls', async () => {
+  const healthUrl = 'http://127.0.0.1:3456/health';
+
+  const ready = await waitForProxyConnection({
+    healthUrl,
+    attempts: 2,
+    httpGetJson: async () => ({ status: 'ok', connected: false }),
+    sleep: async () => {},
+  });
+
+  assert.equal(ready, false);
+});


### PR DESCRIPTION
## 中文

### 背景

我们在 macOS 上使用 `web-access` 连接主 Chrome 时，`check-deps.mjs` 在等待 proxy 就绪的阶段会循环请求 `/targets`。问题在于 `/targets` 并不是纯粹的健康检查：它会进入 `cdp-proxy.mjs` 的正常请求路径，并在尚未完成授权时再次触发 `connect()`。

在我们的复现场景里，这会把一次正常的 Chrome 远程调试授权，放大成连续多次的连接尝试，用户侧表现为短时间内收到一串重复授权请求。

### 修改内容

- 把等待 proxy 就绪的逻辑提取成 `waitForProxyConnection()` helper
- 等待阶段只轮询 `/health`
- 只有 `/health.connected === true` 时才判定 proxy 已 ready，不再用 `/targets` 做探活

### 为什么这样改

`/health` 已经足够表达 check-deps 需要的状态：proxy 是否连上浏览器。

相比之下，`/targets` 会触发更深的请求路径；在浏览器授权尚未完成时，重复请求它会制造额外的连接噪音，但不会带来更多有效信息。

### Test Plan

- [x] 新增单元测试，验证等待逻辑只轮询 `/health`
- [x] 运行 `node --test tests/check-deps-wait.test.mjs`
- [x] 运行 `node scripts/check-deps.mjs --browser chrome`，验证脚本可正常返回 ready

---

## English

### Background

When using `web-access` on macOS against the main Chrome instance, `check-deps.mjs` currently polls `/targets` while waiting for the proxy to become ready. The problem is that `/targets` is not a pure health check: it enters the normal request path in `cdp-proxy.mjs` and can trigger another `connect()` while browser authorization is still pending.

In our repro, that turned a single normal Chrome remote-debugging approval into a burst of repeated connection attempts. On the user side, it showed up as multiple authorization prompts in a short time.

### Changes

- extract the proxy wait logic into a small `waitForProxyConnection()` helper
- poll only `/health` during the wait phase
- consider the proxy ready only when `/health.connected === true`, instead of probing readiness through `/targets`

### Why this change

`/health` already exposes the exact state `check-deps` needs: whether the proxy is connected to a browser.

By contrast, `/targets` exercises a deeper request path. While authorization is still pending, repeatedly hitting it adds connection noise without providing better readiness information.

### Test Plan

- [x] add a unit test asserting the wait loop polls `/health` only
- [x] run `node --test tests/check-deps-wait.test.mjs`
- [x] run `node scripts/check-deps.mjs --browser chrome` and verify it returns ready
