### PR TITLE
fix: 显式 --remote-debugging-port 启动时从 /json/version 取真实 UUID，修复 CDP 连不上

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -99,7 +99,18 @@ async function discoverChromePort() {
   return null;
 }
 
-function getWebSocketUrl(port, wsPath) {
+async function getWebSocketUrl(port, wsPath) {
+  // 优先用 /json/version 的实时 webSocketDebuggerUrl：
+  // 1) 显式 --remote-debugging-port 启动时，浏览器级端点带 UUID，裸 /devtools/browser 连不上；
+  // 2) DevToolsActivePort 里的 UUID 可能是旧实例残留（端口被别的实例接管后不一致）。
+  // 取不到（如 chrome://inspect 授权模式下 /json 被锁返回 404）再回退到已发现的 wsPath。
+  try {
+    const r = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(2000) });
+    if (r.ok) {
+      const j = await r.json();
+      if (j.webSocketDebuggerUrl) return j.webSocketDebuggerUrl;
+    }
+  } catch { /* /json 不可用则回退 */ }
   if (wsPath) return `ws://127.0.0.1:${port}${wsPath}`;
   return `ws://127.0.0.1:${port}/devtools/browser`;
 }
@@ -127,7 +138,7 @@ async function connect() {
     chromeWsPath = discovered.wsPath;
   }
 
-  const wsUrl = getWebSocketUrl(chromePort, chromeWsPath);
+  const wsUrl = await getWebSocketUrl(chromePort, chromeWsPath);
   if (!wsUrl) throw new Error('无法获取 Chrome WebSocket URL');
 
   return connectingPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
## 问题

用 `--remote-debugging-port` 手动启动 Chrome/Edge（而不是在 `chrome://inspect/#remote-debugging` 勾选授权）时，`cdp-proxy` 连不上浏览器，`check-deps` 一直卡在 `proxy: connecting...` 直到超时。

## 根因

`getWebSocketUrl(port, wsPath)` 在 `wsPath` 为空时回退到：

```js
return `ws://127.0.0.1:${port}/devtools/browser`;
```

但 Chrome/Edge 的**浏览器级** WebSocket 端点需要带 UUID 的路径 `/devtools/browser/<uuid>`，裸 `/devtools/browser` 会被拒绝。而 `findFallbackPort()`（手动 `--remote-debugging-port` 场景）返回的 `wsPath` 恒为 `null`，正好走到这条坏路。

此外 `browser-discovery.mjs` 从 `DevToolsActivePort` 第二行读到的 UUID 可能是**旧实例残留**——当该端口已被另一个浏览器实例接管时，文件里的 UUID 与当前实例不一致，同样连不上。

## 修复

`getWebSocketUrl` 改为优先请求 `http://127.0.0.1:<port>/json/version`，用其中实时的 `webSocketDebuggerUrl`（一定带当前实例正确的 UUID）；取不到时才回退原逻辑——兼容 `chrome://inspect` 授权模式（该模式下 `/json` 被锁、返回 404，而此时 `DevToolsActivePort` 里的 UUID 恰好是当前会话的正确值）。

改动仅 13 行，向后兼容，不影响现有的 `chrome://inspect` 授权流程。

## 测试

Chrome 150（macOS），用 `--remote-debugging-port=9222 --user-data-dir=<独立目录>` 启动：

- 打补丁**前**：`cdp-proxy` 卡在 `proxy: connecting`，`/targets` 一直不就绪。
- 打补丁**后**：`/targets` 正常返回；`POST /new`（body=`https://example.com`）打开页面，`POST /eval`（body=`document.title`）返回 `Example Domain`。日志显示 `通过手动调试端口连接: 9222 → 已连接浏览器`。
