### PR TITLE
fix: /close 同样静默吞掉 CDP 错误，且 /navigate 协议失败前会先挂 15 秒

### DIFF
--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -312,6 +312,21 @@ async function readBody(req) {
   return body;
 }
 
+// 回写 CDP 响应。协议级失败时 resp.result 为 undefined，
+// JSON.stringify(undefined) 返回 undefined 而非字符串，res.end(undefined)
+// 会以 HTTP 200 + 空 body 结束，调用方无从判断失败。这里显式区分两者。
+function endWithCDPResult(res, resp) {
+  if (resp.error) {
+    res.statusCode = 400;
+    res.end(JSON.stringify({
+      error: resp.error.message || 'CDP protocol error',
+      code: resp.error.code,
+    }));
+    return;
+  }
+  res.end(JSON.stringify(resp.result ?? {}));
+}
+
 // --- HTTP API ---
 const server = http.createServer(async (req, res) => {
   const parsed = new URL(req.url, `http://localhost:${PORT}`);
@@ -378,7 +393,7 @@ const server = http.createServer(async (req, res) => {
       const resp = await sendCDP('Target.closeTarget', { targetId: q.target });
       sessions.delete(q.target);
       managedTabs.delete(q.target);
-      res.end(JSON.stringify(resp.result));
+      endWithCDPResult(res, resp);
     }
 
     // POST /navigate?target=xxx (body=URL) - 导航（自动等待加载）
@@ -393,13 +408,27 @@ const server = http.createServer(async (req, res) => {
         return;
       }
       const targetUrl = (await readBody(req)).trim();
+      if (!targetUrl) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({
+          error: 'URL 不能为空，请通过 POST body 传入',
+          example: "curl -X POST --data-raw 'https://example.com' 'http://localhost:3456/navigate?target=ID'",
+        }));
+        return;
+      }
       const sid = await ensureSession(q.target);
       const resp = await sendCDP('Page.navigate', { url: targetUrl }, sid);
+
+      // 协议级失败（如 session 已失效）时不再等待加载，直接透出错误
+      if (resp.error) {
+        endWithCDPResult(res, resp);
+        return;
+      }
 
       // 等待页面加载完成
       await waitForLoad(sid);
 
-      res.end(JSON.stringify(resp.result));
+      endWithCDPResult(res, resp);
     }
 
     // GET /back?target=xxx - 后退


### PR DESCRIPTION
## 与 #141 的关系

#141 已指出并修复了 `/navigate` 的空 body 问题，本 PR 在此问题上与其相同。本 PR 还弥补了 #141 未提及的三点（见“改动”小节）。文件改动仅涉及 `cdp-proxy.mjs`，本PR 与 #141 可以共存也可择一。

## 问题

`sendCDP()` 把整条 CDP 响应原样 resolve（`:177`），成功给 `result`、失败给 `error`。`/close`（`:381`）和 `/navigate`（`:402`）直接 `res.end(JSON.stringify(resp.result))`，协议失败时 `resp.result` 为 `undefined`，`JSON.stringify(undefined)` 返回的是 JS 的 `undefined` 值而非字符串，`res.end(undefined)` 以 HTTP 200 加空 body 结束。这两条路径上 `res.statusCode` 从未被赋值，外层 catch（`:606`）也进不去，因为 `sendCDP` 是 resolve 不是 reject。

触发不需要浏览器重启这种场景。`ensureSession`（`:222`）命中缓存就直接短路，`sessions` 只在 WS 断开、闲置清理、主动 `/close` 三处清除，也没有订阅 `Target.detachedFromTarget`，因此用户手动关掉一个 tab 即可。该行为与 `references/cdp-api.md:108` 承诺的「targetId 无效或 tab 已关闭 → attach 失败」不符，实际交付的是 200 加空 body。

## 改动

1. **`/close` 同样静默失败**。#141 仅修改 `/navigate`，未修改相同逻辑的 `/close`，其传错 targetId 时同样 200+空body。
2. **协议失败时跳过 `waitForLoad`**。#141 的判断在 `await waitForLoad(sid)` 之后。session 已失效时 `Page.enable` 和 `Runtime.evaluate` 都返回 error 对象而非抛异常，`readyState` 判定（`:300`）永不成立，会一路轮询到 15 秒超时才返回那个错误。提前 return 后实测 15006ms 降到 3ms。
3. **`/navigate` 空 body 返 400**。`/new`（`:360`）有 `|| 'about:blank'` 兜底，`/navigate`（`:395`）没有，空 URL 会一路走到 CDP 才失败。

## 状态码 400 而非 502

#141 使用的状态码为 502，本 PR 使用 400，理由如下：

本文件既有约定是：
- 调用方错误 400（`:426`、`:439`、`:474`、`:493`、`:512`、`:524`）
- 内部异常 500（`:607`）
- 未知端点 404（`:588`）
- 无 5xx-other 先例

实测触发到的三种 CDP 错误（`-32000` invalid URL、`-32602` no target、`-32001` session not found）都是调用方或状态错误，浏览器本身工作正常，与 502 “上游返回无效响应”的语义不符。

## 未覆盖

同一个写法在全文件有 10 处，本 PR 只动了 2 处（`/close`、`/navigate`）。剩下的分两类：
- 5 处仍然静默返回 200：`/back`（`:410`）、`/eval`（`:429`）、`/click`（`:465`）、`/scroll`（`:557`）、`/info`（`:584`）
- 3 处会返 500 ：/targets、/new、/screenshot。此 3 处为 `resp.result.xxx` 直接解引用,会抛 TypeError 被外层 catch ，对调用方可见

一次性修复的方案是：让 `sendCDP` 在 `resp.error` 时 reject；但这会改变 `ensureSession`（`:221-232`）的错误路径，让 `attach 失败` （写入 `cdp-api.md` 的字符串）永不执行，也会把每端点独立的错误负载统一成 500 加裸 CDP 字符串。此措施属于传输层契约改动，不属于本 PR 范畴，交由维护者决定。

根因（session 缓存不校验存活）本 PR 未修复，仅让失败可见。

## 兼容性

成功路径不变。