### PR TITLE
feat: support remote CDP proxy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,21 @@ skill 长期偏好保存在 `${CLAUDE_SKILL_DIR}/config.env`（首次运行自�
 ```bash
 # 留空 = 每次启动都询问偏好；设值 = 固定使用该浏览器
 WEB_ACCESS_BROWSER=edge
+
+# CDP Proxy 监听设置（有浏览器的机器）
+# 默认允许局域网其他机器通过 http://<本机局域网IP>:3456 调用
+CDP_PROXY_HOST=0.0.0.0
+CDP_PROXY_PORT=3456
+
+# 无浏览器机器：填写有浏览器机器的局域网地址；留空则使用本机浏览器
+CDP_PROXY_BASE_URL=http://192.168.1.10:3456
 ```
 
-合法值：`chrome` / `edge`
+合法值：`WEB_ACCESS_BROWSER=chrome` / `edge`
+
+**局域网远程访问**：有浏览器的机器启动 Proxy 后，其他机器用 `http://<有浏览器机器IP>:3456` 调用 API。无浏览器机器在 `config.env` 设置 `CDP_PROXY_BASE_URL` 后，`check-deps.mjs` 只校验远端 `/health`，不会要求本机浏览器。
+
+> 安全提示：CDP Proxy 是浏览器控制 API，当前没有鉴权。只建议暴露在可信局域网 / VPN 内，并通过系统防火墙限制来源 IP；不要直接暴露到公网。
 
 **临时用别的浏览器**（不修改 config.env）：
 
@@ -157,7 +169,7 @@ Proxy 通过 WebSocket 直连浏览器（兼容 `chrome://inspect` / `edge://ins
 # 启动（Agent 会自动管理 Proxy 生命周期，无需手动启动）
 node "${CLAUDE_SKILL_DIR}/scripts/cdp-proxy.mjs" &
 
-# 页面操作
+# 页面操作（本机用 localhost；远端机器把 localhost 替换成有浏览器机器的局域网 IP）
 curl -s -X POST --data-raw 'https://example.com' http://localhost:3456/new  # 新建 tab（v2.5.3 起 URL 走 POST body）
 curl -s -X POST "http://localhost:3456/eval?target=ID" -d 'document.title'  # 执行 JS
 curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'  # JS 点击

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,45 +109,59 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 
 脚本会依次检查 Node.js、浏览器调试端口，并确保 Proxy 已连接（未运行则自动启动并等待）。Proxy 启动后持续运行。
 
+### 局域网 / 无浏览器机器访问
+
+CDP Proxy 默认监听 `0.0.0.0:3456`，有浏览器的机器启动后，局域网其他机器可以通过 `http://<有浏览器机器的局域网IP>:3456` 调用同一套 Web Access API。若需要只允许本机访问，把 `${CLAUDE_SKILL_DIR}/config.env` 中的 `CDP_PROXY_HOST` 改为 `127.0.0.1` 后重启 proxy。
+
+无浏览器机器不需要本机安装/启动浏览器，在自己的 `${CLAUDE_SKILL_DIR}/config.env` 配置：
+
+```bash
+CDP_PROXY_BASE_URL=http://<有浏览器机器的局域网IP>:3456
+```
+
+配置后运行 `node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"` 会只校验远端 Proxy 的 `/health`，不再尝试发现本机浏览器。后续调用 API 时用这个远端 base URL 替代 `http://localhost:3456`。
+
+> 安全提示：CDP Proxy 是浏览器控制 API，当前没有鉴权。只建议暴露在可信局域网 / VPN 内，并通过系统防火墙限制来源 IP；不要直接暴露到公网。
+
 ### Proxy API
 
-所有操作通过 curl 调用 HTTP API：
+所有操作通过 curl 调用 HTTP API。默认本机 base URL 为 `http://localhost:3456`；无浏览器机器或远程调用时，用 `CDP_PROXY_BASE_URL`（如 `http://192.168.1.10:3456`）替代：
 
 ```bash
 # 列出用户已打开的 tab
-curl -s http://localhost:3456/targets
+curl -s ${CDP_PROXY_BASE_URL:-http://localhost:3456}/targets
 
 # 创建新后台 tab（自动等待加载）— URL 走 POST body，避免目标 URL 含 query 时被切分
-curl -s -X POST --data-raw 'https://example.com' http://localhost:3456/new
+curl -s -X POST --data-raw 'https://example.com' ${CDP_PROXY_BASE_URL:-http://localhost:3456}/new
 
 # 页面信息
-curl -s "http://localhost:3456/info?target=ID"
+curl -s "${CDP_PROXY_BASE_URL:-http://localhost:3456}/info?target=ID"
 
 # 执行任意 JS：可读写 DOM、提取数据、操控元素、触发状态变更、提交表单、调用内部方法
-curl -s -X POST "http://localhost:3456/eval?target=ID" -d 'document.title'
+curl -s -X POST "${CDP_PROXY_BASE_URL:-http://localhost:3456}/eval?target=ID" -d 'document.title'
 
 # 捕获页面渲染状态（含视频当前帧）
-curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"
+curl -s "${CDP_PROXY_BASE_URL:-http://localhost:3456}/screenshot?target=ID&file=/tmp/shot.png"
 
 # 导航（URL 走 POST body，target 走 query）、后退
-curl -s -X POST --data-raw 'https://example.com' "http://localhost:3456/navigate?target=ID"
-curl -s "http://localhost:3456/back?target=ID"
+curl -s -X POST --data-raw 'https://example.com' "${CDP_PROXY_BASE_URL:-http://localhost:3456}/navigate?target=ID"
+curl -s "${CDP_PROXY_BASE_URL:-http://localhost:3456}/back?target=ID"
 
 # 点击（POST body 为 CSS 选择器）— JS el.click()，简单快速，覆盖大多数场景
-curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'
+curl -s -X POST "${CDP_PROXY_BASE_URL:-http://localhost:3456}/click?target=ID" -d 'button.submit'
 
 # 真实鼠标点击 — CDP Input.dispatchMouseEvent，算用户手势，能触发文件对话框
-curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
+curl -s -X POST "${CDP_PROXY_BASE_URL:-http://localhost:3456}/clickAt?target=ID" -d 'button.upload'
 
 # 文件上传 — 直接设置 file input 的本地文件路径，绕过文件对话框
-curl -s -X POST "http://localhost:3456/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'
+curl -s -X POST "${CDP_PROXY_BASE_URL:-http://localhost:3456}/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'
 
 # 滚动（触发懒加载）
-curl -s "http://localhost:3456/scroll?target=ID&y=3000"
-curl -s "http://localhost:3456/scroll?target=ID&direction=bottom"
+curl -s "${CDP_PROXY_BASE_URL:-http://localhost:3456}/scroll?target=ID&y=3000"
+curl -s "${CDP_PROXY_BASE_URL:-http://localhost:3456}/scroll?target=ID&direction=bottom"
 
 # 关闭 tab
-curl -s "http://localhost:3456/close?target=ID"
+curl -s "${CDP_PROXY_BASE_URL:-http://localhost:3456}/close?target=ID"
 ```
 
 ### 页面内导航

--- a/scripts/browser-discovery.mjs
+++ b/scripts/browser-discovery.mjs
@@ -61,7 +61,7 @@ export function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
 
 // 读 config.env 文件（不写入 process.env，分清来源）
 // 格式：KEY=VALUE，# 开头是注释
-function readConfig() {
+export function readConfig() {
   const cfg = {};
   let content;
   try { content = fs.readFileSync(CONFIG_PATH, 'utf8'); }

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
-import { selectBrowser, findFallbackPort } from './browser-discovery.mjs';
+import { selectBrowser, findFallbackPort, readConfig } from './browser-discovery.mjs';
 
 // --- 解析命令行 --browser 参数（本次启动用哪个浏览器）---
 function parseBrowserArg() {
@@ -22,7 +22,9 @@ function parseBrowserArg() {
 }
 const BROWSER_OVERRIDE = parseBrowserArg();
 
-const PORT = parseInt(process.env.CDP_PROXY_PORT || '3456');
+const PROXY_CONFIG = readConfig();
+const PORT = parseInt(process.env.CDP_PROXY_PORT || PROXY_CONFIG.CDP_PROXY_PORT || '3456');
+const HOST = process.env.CDP_PROXY_HOST || PROXY_CONFIG.CDP_PROXY_HOST || '0.0.0.0';
 let ws = null;
 let cmdId = 0;
 const pending = new Map(); // id -> {resolve, timer}
@@ -325,6 +327,7 @@ const server = http.createServer(async (req, res) => {
     // /health 不需要连接浏览器
     if (pathname === '/health') {
       const connected = ws && (ws.readyState === WS.OPEN || ws.readyState === 1);
+      const bind = HOST === '0.0.0.0' || HOST === '::' ? 'localhost / LAN IP' : HOST;
       res.end(JSON.stringify({
         status: 'ok',
         connected,
@@ -332,6 +335,7 @@ const server = http.createServer(async (req, res) => {
         sessions: sessions.size,
         managedTabs: managedTabs.size,
         chromePort,
+        proxy: { host: HOST, port: PORT, bind },
       }));
       return;
     }
@@ -610,18 +614,18 @@ const server = http.createServer(async (req, res) => {
 });
 
 // 检查端口是否被占用
-function checkPortAvailable(port) {
+function checkPortAvailable(port, host) {
   return new Promise((resolve) => {
     const s = net.createServer();
     s.once('error', () => resolve(false));
     s.once('listening', () => { s.close(); resolve(true); });
-    s.listen(port, '127.0.0.1');
+    s.listen(port, host);
   });
 }
 
 async function main() {
   // 检查是否已有 proxy 在运行
-  const available = await checkPortAvailable(PORT);
+  const available = await checkPortAvailable(PORT, HOST);
   if (!available) {
     // 验证已有实例是否健康
     try {
@@ -641,8 +645,12 @@ async function main() {
     process.exit(1);
   }
 
-  server.listen(PORT, '127.0.0.1', () => {
-    console.log(`[CDP Proxy] 运行在 http://localhost:${PORT}`);
+  server.listen(PORT, HOST, () => {
+    const localUrl = `http://localhost:${PORT}`;
+    const bindDesc = HOST === '0.0.0.0' || HOST === '::'
+      ? `${localUrl}（局域网可通过 http://<本机局域网IP>:${PORT} 访问）`
+      : `http://${HOST}:${PORT}`;
+    console.log(`[CDP Proxy] 运行在 ${bindDesc}`);
     // 启动时尝试连接 Chrome（非阻塞）
     connect().catch(e => console.error('[CDP Proxy] 初始连接失败:', e.message, '（将在首次请求时重试）'));
   });

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -13,11 +13,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { selectBrowser, knownBrowsers, findFallbackPort } from './browser-discovery.mjs';
+import { selectBrowser, knownBrowsers, findFallbackPort, readConfig } from './browser-discovery.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PROXY_SCRIPT = path.join(ROOT, 'scripts', 'cdp-proxy.mjs');
-const PROXY_PORT = Number(process.env.CDP_PROXY_PORT || 3456);
+const PROXY_PORT = Number(process.env.CDP_PROXY_PORT || readConfig().CDP_PROXY_PORT || 3456);
 const CONFIG_PATH = path.join(ROOT, 'config.env');
 const CONFIG_TEMPLATE = path.join(ROOT, 'templates', 'config.env.template');
 
@@ -42,6 +42,27 @@ function ensureConfigExists() {
   } catch {
     // 模板不存在或拷贝失败 —— 不阻塞，readConfig 会兜底
   }
+}
+
+function normalizeProxyBase(raw) {
+  if (!raw) return null;
+  const value = raw.trim().replace(/\/+$/, '');
+  if (!value) return null;
+  return /^https?:\/\//i.test(value) ? value : `http://${value}`;
+}
+
+async function ensureRemoteProxy(proxyBase) {
+  const health = await httpGetJson(`${proxyBase}/health`, 5000);
+  if (health?.status !== 'ok') {
+    console.log(`proxy: remote unavailable — ${proxyBase}`);
+    console.log('  请确认有浏览器的机器已启动 cdp-proxy，且防火墙允许 3456 端口局域网访问');
+    return false;
+  }
+  const connected = health.connected ? 'connected' : 'not connected';
+  const browser = health.browser?.label || health.browser?.id || 'unknown';
+  console.log(`proxy: remote ready (${proxyBase}, ${connected}, browser: ${browser})`);
+  console.log(`  无浏览器机器后续调用请使用：${proxyBase}/targets、${proxyBase}/new 等 API`);
+  return true;
 }
 
 // --- Node.js 版本检查 ---
@@ -184,6 +205,13 @@ async function main() {
   const opts = parseArgs(process.argv.slice(2));
   ensureConfigExists();
   checkNode();
+
+  const proxyBase = normalizeProxyBase(process.env.CDP_PROXY_BASE_URL || readConfig().CDP_PROXY_BASE_URL);
+  if (proxyBase) {
+    const proxyOk = await ensureRemoteProxy(proxyBase);
+    if (!proxyOk) process.exit(1);
+    return;
+  }
 
   const { proceed, exitCode, browserId } = await resolveAndReport(opts.browser);
   if (!proceed) process.exit(exitCode);

--- a/templates/config.env.template
+++ b/templates/config.env.template
@@ -7,3 +7,14 @@
 #
 # 合法值：chrome / edge
 WEB_ACCESS_BROWSER=
+
+# CDP Proxy 监听设置（有浏览器的机器）
+# 默认监听 0.0.0.0，允许局域网其他机器通过 http://<本机局域网IP>:3456 调用本机 Web Access。
+# 若只允许本机访问，改成 127.0.0.1。
+CDP_PROXY_HOST=0.0.0.0
+CDP_PROXY_PORT=3456
+
+# 远端 CDP Proxy（无浏览器的机器）
+# 在没有浏览器的机器上填有浏览器机器的局域网地址；留空则使用本机浏览器。
+# 示例：CDP_PROXY_BASE_URL=http://192.168.1.10:3456
+CDP_PROXY_BASE_URL=


### PR DESCRIPTION
Adds configurable CDP Proxy host and port settings, defaulting to LAN-accessible 0.0.0.0:3456. Supports browserless machines through CDP_PROXY_BASE_URL by checking and calling a remote Web Access proxy. Updates configuration templates and documentation, including the security warning that the unauthenticated proxy should only be exposed on trusted LAN or VPN networks. Validation: node --check scripts/cdp-proxy.mjs; node --check scripts/check-deps.mjs; remote proxy failure-path check.