### PR TITLE
fix: 避免在 Codex 沙箱中误报远程调试未开启

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 在开始联网操作前，先检查 CDP 模式可用性：
 
+**Codex / 沙箱宿主**：在 Codex 等会限制本地回环连接的宿主中，首次运行 `check-deps.mjs` 就必须申请在受限/沙箱环境外执行（例如 Codex 的 `sandbox_permissions: require_escalated`），因为该脚本还会启动持续运行的 Proxy，子进程会继承当前执行限制。不要先在默认沙箱内试跑；也不要在完成一次非受限检查前告诉用户远程调试开关未启用。
+
 ```bash
 node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```
@@ -25,7 +27,7 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 按脚本输出处理：
 - `exit 0` → 继续
 - `exit 2` → 需询问用户偏好，写入 `${CLAUDE_SKILL_DIR}/config.env` 的 `WEB_ACCESS_BROWSER`
-- `exit 1` → 按 stdout 错误信息处理。若提示包含「Agent 处理顺序」，按其步骤执行（如先用系统命令打开浏览器后重跑），自动可解则不打扰用户；仍失败再向用户求助
+- `exit 1` → 按 stdout 错误信息处理。若提示当前执行环境 `restricted` 或出现 `EPERM` / `EACCES`，这不代表浏览器未开启调试；应在受限/沙箱环境外重新运行同一条 `check-deps.mjs` 命令，让 Proxy 也在非受限环境中启动。其他错误若包含「Agent 处理顺序」，按其步骤执行；自动可解则不打扰用户，仍失败再向用户求助
 
 支持参数 `--browser <chrome|edge>` 表达本次临时覆盖（不写 config.env）。
 

--- a/scripts/browser-discovery.mjs
+++ b/scripts/browser-discovery.mjs
@@ -50,12 +50,37 @@ export function knownBrowsers() {
 
 // TCP 端口监听检测
 // 用 TCP connect 而非 WebSocket，避免触发浏览器的远程调试授权弹窗。
+// EPERM / EACCES 表示当前执行环境不允许访问 localhost，不能据此判断浏览器未开启调试。
+export function classifyPortError(errorCode) {
+  return errorCode === 'EPERM' || errorCode === 'EACCES' ? 'restricted' : 'unreachable';
+}
+
 export function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
   return new Promise((resolve) => {
-    const socket = net.createConnection(port, host);
-    const timer = setTimeout(() => { socket.destroy(); resolve(false); }, timeoutMs);
-    socket.once('connect', () => { clearTimeout(timer); socket.destroy(); resolve(true); });
-    socket.once('error',   () => { clearTimeout(timer); resolve(false); });
+    let socket;
+    let timer;
+    let settled = false;
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket?.destroy();
+      resolve(result);
+    };
+
+    try {
+      socket = net.createConnection(port, host);
+    } catch (error) {
+      finish({ status: classifyPortError(error?.code), errorCode: error?.code || null });
+      return;
+    }
+
+    timer = setTimeout(() => finish({ status: 'unreachable', errorCode: 'ETIMEDOUT' }), timeoutMs);
+    socket.once('connect', () => finish({ status: 'open', errorCode: null }));
+    socket.once('error', (error) => {
+      finish({ status: classifyPortError(error?.code), errorCode: error?.code || null });
+    });
   });
 }
 
@@ -78,9 +103,10 @@ function readConfig() {
   return cfg;
 }
 
-// 返回所有开了 toggle 且端口活的浏览器
+// 返回所有端口可达或被当前执行环境阻止探测的浏览器。
 async function detectAll() {
-  const result = [];
+  const detected = [];
+  const restricted = [];
   for (const browser of knownBrowsers()) {
     let content;
     try { content = fs.readFileSync(browser.devToolsPath, 'utf8'); }
@@ -88,51 +114,66 @@ async function detectAll() {
     const lines = content.trim().split(/\r?\n/).filter(Boolean);
     const port = parseInt(lines[0], 10);
     if (!(port > 0 && port < 65536)) continue;
-    if (!(await checkPort(port))) continue;
-    result.push({ ...browser, port, wsPath: lines[1] || null });
+    const candidate = { ...browser, port, wsPath: lines[1] || null };
+    const probe = await checkPort(port);
+    if (probe.status === 'open') detected.push(candidate);
+    else if (probe.status === 'restricted') restricted.push({ ...candidate, errorCode: probe.errorCode });
   }
-  return result;
+  return { detected, restricted };
 }
 
 // 决策入口
 // 参数：override — 调用方解析自命令行 --browser 的值（null 表示未传）
-// 返回 { kind, browser?, source?, detected, configured, override? }
-//   kind ∈ 'ok' | 'ambiguous' | 'mismatch' | 'empty'
+// 返回 { kind, browser?, source?, detected, restricted, configured, override? }
+//   kind ∈ 'ok' | 'ambiguous' | 'restricted' | 'mismatch' | 'empty'
 //   source ∈ 'override' | 'preference' | undefined
 //   ambiguous = 没设偏好 + 至少一个浏览器开了 toggle，需问用户
+//   restricted = 找到了调试端口文件，但当前环境无权连接 localhost
 //   mismatch  = override/配偏好设了但未检测到对应 toggle，硬错
 //   empty     = 0 浏览器开 toggle 且未设偏好/override
-export async function selectBrowser(override = null) {
-  const detected = await detectAll();
-  const configured = readConfig().WEB_ACCESS_BROWSER || null;
-
+export function resolveBrowserSelection({ detected, restricted, configured, override }) {
   // 1. 命令行 override（最高优先，单次有效）
   if (override) {
     const match = detected.find(b => b.id === override);
-    if (match) return { kind: 'ok', browser: match, source: 'override', detected, configured, override };
-    return { kind: 'mismatch', source: 'override', detected, configured, override };
+    if (match) return { kind: 'ok', browser: match, source: 'override', detected, restricted, configured, override };
+    const blocked = restricted.find(b => b.id === override);
+    if (blocked) return { kind: 'restricted', browser: blocked, source: 'override', detected, restricted, configured, override };
+    return { kind: 'mismatch', source: 'override', detected, restricted, configured, override };
   }
 
   // 2. config.env preference（持久）
   if (configured) {
     const match = detected.find(b => b.id === configured);
-    if (match) return { kind: 'ok', browser: match, source: 'preference', detected, configured };
-    return { kind: 'mismatch', source: 'preference', detected, configured };
+    if (match) return { kind: 'ok', browser: match, source: 'preference', detected, restricted, configured };
+    const blocked = restricted.find(b => b.id === configured);
+    if (blocked) return { kind: 'restricted', browser: blocked, source: 'preference', detected, restricted, configured };
+    return { kind: 'mismatch', source: 'preference', detected, restricted, configured };
   }
 
   // 3. 无偏好 —— 一律询问用户（哪怕 detected 只有一个）
   if (detected.length === 0) {
-    return { kind: 'empty', detected, configured };
+    if (restricted.length) return { kind: 'restricted', detected, restricted, configured };
+    return { kind: 'empty', detected, restricted, configured };
   }
-  return { kind: 'ambiguous', detected, configured };
+  return { kind: 'ambiguous', detected, restricted, configured };
+}
+
+export async function selectBrowser(override = null) {
+  const { detected, restricted } = await detectAll();
+  const configured = readConfig().WEB_ACCESS_BROWSER || null;
+  return resolveBrowserSelection({ detected, restricted, configured, override });
 }
 
 // 兜底：扫描常用固定端口
 // 适用场景：用户手动 --remote-debugging-port=9222 启动浏览器，
 // 此时 DevToolsActivePort 可能不在默认 user-data-dir。
 export async function findFallbackPort() {
+  const restricted = [];
   for (const port of [9222, 9229, 9333]) {
-    if (await checkPort(port)) return port;
+    const probe = await checkPort(port);
+    if (probe.status === 'open') return { kind: 'ok', port };
+    if (probe.status === 'restricted') restricted.push({ port, errorCode: probe.errorCode });
   }
-  return null;
+  if (restricted.length) return { kind: 'restricted', restricted };
+  return { kind: 'empty' };
 }

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
-import { selectBrowser, findFallbackPort } from './browser-discovery.mjs';
+import { classifyPortError, selectBrowser, findFallbackPort } from './browser-discovery.mjs';
 
 // --- 解析命令行 --browser 参数（本次启动用哪个浏览器）---
 function parseBrowserArg() {
@@ -55,6 +55,18 @@ let pinnedBrowserId = null;
 
 // --- 自动发现浏览器调试端口 ---
 // 决策完全委派给 browser-discovery.selectBrowser；此处只做日志和返回结构包装。
+function restrictedConnectionError(result) {
+  const blocked = result.browser ? [result.browser] : (result.restricted || []);
+  const endpoints = blocked.map((b) => {
+    const label = b.label || '本地调试端口';
+    return `${label} 127.0.0.1:${b.port} (${b.errorCode || 'permission denied'})`;
+  });
+  return new Error(
+    `当前执行环境无权访问 ${endpoints.join('、') || '浏览器本地调试端口'}。` +
+    `这不代表远程调试开关未启用。请在受限/沙箱环境外重新运行 check-deps.mjs，让 Proxy 也在非受限环境中启动。`
+  );
+}
+
 async function discoverChromePort() {
   const result = await selectBrowser(BROWSER_OVERRIDE);
   if (result.kind === 'ok') {
@@ -69,6 +81,9 @@ async function discoverChromePort() {
     const tag = result.source === 'override' ? '[--browser 指定]' : '[config.env 偏好]';
     console.log(`[CDP Proxy] 选用 ${result.browser.label} (端口 ${result.browser.port}${result.browser.wsPath ? '，带 wsPath' : ''}) ${tag}`);
     return { port: result.browser.port, wsPath: result.browser.wsPath };
+  }
+  if (result.kind === 'restricted') {
+    throw restrictedConnectionError(result);
   }
   // mismatch：有显式偏好但未检测到 —— 硬错，绝不降级
   if (result.kind === 'mismatch') {
@@ -90,11 +105,14 @@ async function discoverChromePort() {
     );
   }
   // 仅在「从未成功连接 + 无偏好/override」时允许固定端口兜底（手动 --remote-debugging-port 启动场景）
-  const fallbackPort = await findFallbackPort();
-  if (fallbackPort !== null) {
+  const fallback = await findFallbackPort();
+  if (fallback.kind === 'ok') {
     connectedBrowser = { id: 'unknown', label: '未知（通过手动调试端口连接）', source: 'fallback' };
-    console.log(`[CDP Proxy] 通过手动调试端口连接: ${fallbackPort}`);
-    return { port: fallbackPort, wsPath: null };
+    console.log(`[CDP Proxy] 通过手动调试端口连接: ${fallback.port}`);
+    return { port: fallback.port, wsPath: null };
+  }
+  if (fallback.kind === 'restricted') {
+    throw restrictedConnectionError(fallback);
   }
   return null;
 }
@@ -613,16 +631,23 @@ const server = http.createServer(async (req, res) => {
 function checkPortAvailable(port) {
   return new Promise((resolve) => {
     const s = net.createServer();
-    s.once('error', () => resolve(false));
-    s.once('listening', () => { s.close(); resolve(true); });
+    s.once('error', (error) => resolve({ available: false, errorCode: error?.code || null }));
+    s.once('listening', () => { s.close(); resolve({ available: true, errorCode: null }); });
     s.listen(port, '127.0.0.1');
   });
 }
 
 async function main() {
   // 检查是否已有 proxy 在运行
-  const available = await checkPortAvailable(PORT);
-  if (!available) {
+  const portProbe = await checkPortAvailable(PORT);
+  if (!portProbe.available) {
+    if (classifyPortError(portProbe.errorCode) === 'restricted') {
+      console.error(
+        `[CDP Proxy] 当前执行环境无权监听 127.0.0.1:${PORT} (${portProbe.errorCode})。` +
+        `请在受限/沙箱环境外重新运行 check-deps.mjs。`
+      );
+      process.exit(1);
+    }
     // 验证已有实例是否健康
     try {
       const ok = await new Promise((resolve) => {

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -130,6 +130,19 @@ function printAvailableHint(detected) {
   }
 }
 
+function printRestrictedHint(result) {
+  const blocked = result.browser ? [result.browser] : (result.restricted || []);
+  const endpoints = blocked.map((b) => {
+    const label = b.label || '本地调试端口';
+    return `${label} 127.0.0.1:${b.port} (${b.errorCode || 'permission denied'})`;
+  });
+  console.log(`browser: restricted — 当前执行环境无权访问 ${endpoints.join('、') || '浏览器本地调试端口'}`);
+  console.log('  这不代表浏览器未启动，也不代表远程调试开关未启用。');
+  console.log('  Agent 处理顺序：');
+  console.log('    1. 在受限/沙箱环境外重新运行同一条 node check-deps.mjs 命令，让 Proxy 也在非受限环境中启动');
+  console.log('    2. 只有非受限重跑仍失败时，才让用户检查浏览器的远程调试开关');
+}
+
 async function resolveAndReport(override) {
   const result = await selectBrowser(override);
 
@@ -146,6 +159,11 @@ async function resolveAndReport(override) {
       console.log('  请询问用户：哪个浏览器作为 Agent 的默认？（写入 config.env 的 WEB_ACCESS_BROWSER）');
       console.log('  若仅本次使用，可重跑：node check-deps.mjs --browser <id>');
       return { proceed: false, exitCode: 2 };
+    }
+
+    case 'restricted': {
+      printRestrictedHint(result);
+      return { proceed: false, exitCode: 1 };
     }
 
     case 'mismatch': {
@@ -165,10 +183,14 @@ async function resolveAndReport(override) {
 
     case 'empty': {
       // 末路兜底：尝试常见固定端口（用户手动 --remote-debugging-port=9222 启动的场景）
-      const fallbackPort = await findFallbackPort();
-      if (fallbackPort) {
-        console.log(`browser: ok (port ${fallbackPort}) [通过手动调试端口连接]`);
+      const fallback = await findFallbackPort();
+      if (fallback.kind === 'ok') {
+        console.log(`browser: ok (port ${fallback.port}) [通过手动调试端口连接]`);
         return { proceed: true };
+      }
+      if (fallback.kind === 'restricted') {
+        printRestrictedHint(fallback);
+        return { proceed: false, exitCode: 1 };
       }
       console.log('browser: 未连接 — 没有任何浏览器打开远程调试开关');
       console.log(`  支持的浏览器：${knownBrowsers().map(b => b.label).join('、')}`);

--- a/tests/browser-discovery.test.mjs
+++ b/tests/browser-discovery.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import net from 'node:net';
+import test from 'node:test';
+
+import {
+  checkPort,
+  classifyPortError,
+  findFallbackPort,
+  resolveBrowserSelection,
+} from '../scripts/browser-discovery.mjs';
+
+const edge = {
+  id: 'edge',
+  label: 'Microsoft Edge',
+  port: 9222,
+  wsPath: '/devtools/browser/test',
+};
+
+const skillInstructions = fs.readFileSync(new URL('../SKILL.md', import.meta.url), 'utf8');
+
+test('instructs Codex to request an unsandboxed CDP preflight on the first attempt', () => {
+  assert.match(
+    skillInstructions,
+    /Codex[^\n]*首次运行 `check-deps\.mjs` 就必须申请在受限\/沙箱环境外执行/
+  );
+  assert.match(skillInstructions, /不要先在默认沙箱内试跑/);
+});
+
+test('classifies sandbox permission errors separately from unreachable ports', () => {
+  assert.equal(classifyPortError('EPERM'), 'restricted');
+  assert.equal(classifyPortError('EACCES'), 'restricted');
+  assert.equal(classifyPortError('ECONNREFUSED'), 'unreachable');
+  assert.equal(classifyPortError('ETIMEDOUT'), 'unreachable');
+});
+
+test('checkPort preserves EPERM from the socket probe', async (t) => {
+  const socket = new EventEmitter();
+  socket.destroy = () => {};
+  t.mock.method(net, 'createConnection', () => socket);
+
+  const resultPromise = checkPort(9222, '127.0.0.1', 100);
+  queueMicrotask(() => {
+    const error = new Error('operation not permitted');
+    error.code = 'EPERM';
+    socket.emit('error', error);
+  });
+
+  assert.deepEqual(await resultPromise, { status: 'restricted', errorCode: 'EPERM' });
+});
+
+test('fallback port scanning preserves restricted probes', async (t) => {
+  t.mock.method(net, 'createConnection', () => {
+    const socket = new EventEmitter();
+    socket.destroy = () => {};
+    queueMicrotask(() => {
+      const error = new Error('operation not permitted');
+      error.code = 'EPERM';
+      socket.emit('error', error);
+    });
+    return socket;
+  });
+
+  const result = await findFallbackPort();
+  assert.equal(result.kind, 'restricted');
+  assert.deepEqual(result.restricted.map(({ port, errorCode }) => ({ port, errorCode })), [
+    { port: 9222, errorCode: 'EPERM' },
+    { port: 9229, errorCode: 'EPERM' },
+    { port: 9333, errorCode: 'EPERM' },
+  ]);
+});
+
+test('reports an explicitly selected browser as restricted instead of mismatched', () => {
+  const result = resolveBrowserSelection({
+    detected: [],
+    restricted: [{ ...edge, errorCode: 'EPERM' }],
+    configured: null,
+    override: 'edge',
+  });
+
+  assert.equal(result.kind, 'restricted');
+  assert.equal(result.source, 'override');
+  assert.equal(result.browser.id, 'edge');
+  assert.equal(result.browser.errorCode, 'EPERM');
+});
+
+test('reports a configured browser as restricted instead of mismatched', () => {
+  const result = resolveBrowserSelection({
+    detected: [],
+    restricted: [{ ...edge, errorCode: 'EACCES' }],
+    configured: 'edge',
+    override: null,
+  });
+
+  assert.equal(result.kind, 'restricted');
+  assert.equal(result.source, 'preference');
+  assert.equal(result.browser.id, 'edge');
+});
+
+test('reports a restricted environment when no browser preference exists', () => {
+  const result = resolveBrowserSelection({
+    detected: [],
+    restricted: [{ ...edge, errorCode: 'EPERM' }],
+    configured: null,
+    override: null,
+  });
+
+  assert.equal(result.kind, 'restricted');
+  assert.equal(result.browser, undefined);
+  assert.equal(result.restricted[0].id, 'edge');
+});
+
+test('keeps the existing mismatch result for genuinely unreachable browsers', () => {
+  const result = resolveBrowserSelection({
+    detected: [],
+    restricted: [],
+    configured: null,
+    override: 'edge',
+  });
+
+  assert.equal(result.kind, 'mismatch');
+});


### PR DESCRIPTION
## 问题背景

在 Codex 等限制本地回环连接的沙箱环境中，即使 Microsoft Edge 已在 `edge://inspect/#remote-debugging` 开启远程调试，`check-deps.mjs` 对 `127.0.0.1:<port>` 的 TCP 探测仍可能返回 `EPERM` 或 `EACCES`。

原实现把所有 socket 错误统一折叠为 `false`。后续浏览器选择逻辑无法区分以下两种情况：

1. 浏览器确实没有开启远程调试或端口不可达；
2. 浏览器端口存在，但当前 Agent 沙箱无权访问 localhost。

因此第二种情况会被错误映射为 `mismatch`，最终提示用户再次开启 Edge 的远程调试开关。实际在受限环境外运行同一检查时，Edge 的 `9222` 端口可以正常连接。

## 根因

`browser-discovery.mjs` 的 `checkPort()` 只返回布尔值，丢失了 `EPERM`、`EACCES`、`ECONNREFUSED` 等底层错误码。调用方只能把“探测失败”理解为“浏览器远程调试未开启”。

此外，CDP Proxy 检查自身监听端口时也会把监听权限错误当成普通的“端口已被占用”，属于同一类误诊。

## 修复内容

- 将端口探测结果改为结构化状态：`open`、`restricted`、`unreachable`。
- 将 `EPERM` / `EACCES` 明确分类为 `restricted`，并在浏览器选择、固定端口兜底和 Proxy 启动路径中完整传递该状态。
- `check-deps.mjs` 遇到 `restricted` 时明确说明：这不代表浏览器未启动，也不代表远程调试开关未开启；Agent 应先在受限/沙箱环境外重新运行同一条检查命令。
- 只有非受限检查仍然失败时，才提示用户检查浏览器远程调试开关。
- 更新 `SKILL.md`：Codex 首次执行 CDP 前置检查时直接申请在沙箱外运行，避免先产生一次已知会误导的失败；Proxy 子进程也会继承正确的执行权限。
- 保留真实不可达场景的原有 `mismatch` 行为，不会掩盖浏览器确实未开启远程调试的问题。

## 用户影响

修复后，Codex 使用 Web Access 连接已开启远程调试的 Edge 时，不会再因为沙箱的 localhost 权限限制而错误告诉用户“远程调试开关未开启”。Agent 会直接请求在受限环境外执行实际连接检查。

## 验证

- `node --test tests/browser-discovery.test.mjs`：8 项测试全部通过。
- `node --check scripts/browser-discovery.mjs`
- `node --check scripts/check-deps.mjs`
- `node --check scripts/cdp-proxy.mjs`
- `git diff --check`
- 在 Codex 沙箱内运行 `node scripts/check-deps.mjs --browser edge`：正确输出 `browser: restricted` 和 `EPERM`，不再把它解释为 Edge 开关未开启。
- 在同一台机器、同一 Edge 实例上从沙箱外运行相同命令：成功识别 `Microsoft Edge, port 9222`，并输出 `proxy: ready (Microsoft Edge)`。

回归测试还覆盖：

- `EPERM` / `EACCES` 与 `ECONNREFUSED` / `ETIMEDOUT` 的分类差异；
- 显式 `--browser edge` 与 `config.env` 偏好两条路径；
- 固定调试端口兜底扫描；
- 没有浏览器偏好时的受限环境；
- 真正不可达时仍返回 `mismatch`；
- `SKILL.md` 要求 Codex 首次检查即在沙箱外执行。
