### PR TITLE
feat: support file uploads in cross-origin iframe/OOPIF via the existing CDP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ AI Agent 原本的联网能力（WebSearch、WebFetch）缺少调度策略和浏
 |------|------|
 | 联网工具自动选择 | WebSearch / WebFetch / curl / Jina / CDP，按场景自主判断，可任意组合 |
 | CDP Proxy 浏览器操作 | 直连用户日常浏览器（Chrome / Edge / Chromium 系），天然携带登录态，支持动态页面、交互操作、视频截帧 |
-| 三种点击方式 | `/click`（JS click）、`/clickAt`（CDP 真实鼠标事件）、`/setFiles`（文件上传） |
+| 三种点击方式 | `/click`（JS click）、`/clickAt`（CDP 真实鼠标事件）、`/setFiles`（主文档及跨域 iframe/OOPIF 文件上传） |
 | 本地浏览器书签/历史检索 | `find-url.mjs` 跨 Chrome / Edge 查询公网搜不到的目标（内部系统）或用户访问过的页面，支持关键词/时间窗/访问频度排序 |
 | 并行分治 | 多目标时分发子 Agent 并行执行，共享一个 Proxy，tab 级隔离 |
 | 站点经验积累 | 按域名存储操作经验（URL 模式、平台特征、已知陷阱），跨 session 复用 |
@@ -164,6 +164,8 @@ curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'  # JS
 curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d '.upload-btn'  # 真实鼠标点击
 curl -s -X POST "http://localhost:3456/setFiles?target=ID" \
   -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'        # 文件上传
+curl -s -X POST "http://localhost:3456/setFiles?target=ID" \
+  -d '{"selector":"input[type=file]","files":["/path/to/file.pdf"],"frameUrl":"upload.example.com"}' # 跨域 iframe 上传
 curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"     # 截图
 curl -s "http://localhost:3456/scroll?target=ID&direction=bottom"           # 滚动
 curl -s "http://localhost:3456/close?target=ID"                             # 关闭 tab

--- a/SKILL.md
+++ b/SKILL.md
@@ -139,8 +139,12 @@ curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'
 # 真实鼠标点击 — CDP Input.dispatchMouseEvent，算用户手势，能触发文件对话框
 curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
 
-# 文件上传 — 直接设置 file input 的本地文件路径，绕过文件对话框
+# 主文档文件上传 — 直接设置 file input，绕过 Finder/Explorer 的 Open/Save 对话框
 curl -s -X POST "http://localhost:3456/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'
+
+# 跨域 iframe/OOPIF 文件上传 — 复用同一 proxy WebSocket；用稳定 URL 子串限定 frame
+curl -s -X POST "http://localhost:3456/setFiles?target=ID" \
+  -d '{"selector":"input[type=file]","files":["/path/to/file.pdf"],"frameUrl":"upload.example.com"}'
 
 # 滚动（触发懒加载）
 curl -s "http://localhost:3456/scroll?target=ID&y=3000"
@@ -157,6 +161,12 @@ curl -s "http://localhost:3456/close?target=ID"
 - **`/click`**：在当前 tab 内直接点击用户视角中的可交互单元，简单直接，串行处理。适合需要在同一页面内连续操作的场景，如点击展开、翻页、进入详情等。
 - **`/new` + 完整 URL**：使用目标链接的完整地址（包含所有URL参数），在新 tab 中打开。适合需要同时访问多个页面的场景。
 
+### 文件上传
+
+- 任务全程复用同一个长驻 proxy 和同一个业务 `targetId`。不得为文件上传停止/重启 proxy，也不得另起 Playwright、Puppeteer 或第二条 CDP WebSocket。
+- 跨域 iframe/OOPIF 中的文件控件使用 `/setFiles` 的 `frameUrl` 限定；仍有多个候选时再提供 `frameIndex`。不要用固定屏幕坐标猜测文件控件。
+- 自动上传直接设置 file input，不打开系统 Open/Save 窗口。用户主动点击“下载”后出现 Save 窗口属于下载流程，不代表 `/setFiles` 失败。
+
 很多网站的链接包含会话相关的参数（如 token），这些参数是正常访问所必需的。提取 URL 时应保留完整地址，不要裁剪或省略参数。URL 通过 POST body 原样传入 `/new` 或 `/navigate`。
 
 > **v2.5.3 迁移提示**：若引用的站点经验文件（`references/site-patterns/*.md`）或其它脚本中仍含 `GET /new?url=...` 或 `/navigate?target=...&url=...` 的旧写法，调用会收到迁移指引。按 [`references/migration-2.5.3.md`](references/migration-2.5.3.md) 就地改写为 POST body 后再使用，并顺手把该站点经验文件更新掉。
@@ -167,7 +177,7 @@ curl -s "http://localhost:3456/close?target=ID"
 
 ### 技术事实
 - 页面中存在大量已加载但未展示的内容——轮播中非当前帧的图片、折叠区块的文字、懒加载占位元素等，它们存在于 DOM 中但对用户不可见。以数据结构（容器、属性、节点关系）为单位思考，可以直接触达这些内容。
-- DOM 中存在选择器不可跨越的边界（Shadow DOM 的 `shadowRoot`、iframe 的 `contentDocument`等）。eval 递归遍历可一次穿透所有层级，返回带标签的结构化内容，适合快速了解未知页面的完整结构。
+- DOM 中存在选择器不可跨越的边界。开放的 Shadow DOM 和同进程 iframe 可递归读取；跨域 OOPIF 需要附加其独立 CDP session。文件上传使用 `/setFiles`，由同一 proxy 按 target 父子关系限定到指定页面。
 - `/scroll` 到底部会触发懒加载，使未进入视口的图片完成加载。提取图片 URL 前若未滚动，部分图片可能尚未加载。
 - 拿到媒体资源 URL 后，公开资源可直接下载到本地后用读取；需要登录态才可获取的资源才需要在浏览器内 navigate + screenshot。
 - 短时间内密集打开大量页面（如批量 `/new`）可能触发网站的反爬风控。

--- a/references/cdp-api.md
+++ b/references/cdp-api.md
@@ -74,9 +74,25 @@ curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
 ```
 
 ### POST /setFiles?target=ID
-给 file input 设置本地文件路径（`DOM.setFileInputFiles`），完全绕过文件对话框。POST body 为 JSON。
+在主文档、同进程 iframe/开放 Shadow DOM，或属于指定页面的跨域 iframe/OOPIF 中给 file input 设置本地文件路径（`DOM.setFileInputFiles`）。操作复用 proxy 已有的 browser WebSocket，完全绕过系统 Open/Save 对话框。
+
+- `selector`：必填，非空 CSS selector。
+- `files`：必填，非空路径数组；路径会转换为绝对路径、去重，并验证存在且为普通文件。
+- `frameUrl`：可选，以稳定 URL 子串限定 document/frame。
+- `frameIndex`：可选，仍有多个候选时从 0 开始明确选择。
+- 只有一个候选时自动选择；多个候选且限定不足时返回 `409`，不会猜测或修改任何控件。
+
 ```bash
 curl -s -X POST "http://localhost:3456/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file1.png","/path/to/file2.png"]}'
+
+curl -s -X POST "http://localhost:3456/setFiles?target=ID" \
+  -d '{"selector":"input[type=file]","files":["/path/to/file.pdf"],"frameUrl":"upload.example.com"}'
+```
+
+成功响应会说明实际使用的上下文：
+
+```json
+{"success":true,"files":1,"targetId":"...","context":"iframe","frameUrl":"https://upload.example.com/form"}
 ```
 
 ### GET /scroll?target=ID&y=3000&direction=down
@@ -108,3 +124,4 @@ curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"
 | `attach 失败` | targetId 无效或 tab 已关闭 | 用 `/targets` 获取最新列表 |
 | `CDP 命令超时` | 页面长时间未响应 | 重试或检查 tab 状态 |
 | `端口已被占用` | 另一个 proxy 已在运行 | 已有实例可直接复用 |
+| `找到多个匹配文件控件` | selector/frameUrl 限定不足 | 增加稳定的 `frameUrl`，必要时再提供 `frameIndex` |

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -10,6 +10,7 @@ import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
 import { selectBrowser, findFallbackPort } from './browser-discovery.mjs';
+import { createSetFilesAcrossFrames, SetFilesError } from './set-files.mjs';
 
 // --- 解析命令行 --browser 参数（本次启动用哪个浏览器）---
 function parseBrowserArg() {
@@ -230,6 +231,8 @@ async function ensureSession(targetId) {
   }
   throw new Error('attach 失败: ' + JSON.stringify(resp.error));
 }
+
+const setFilesAcrossFrames = createSetFilesAcrossFrames({ sendCDP, ensureSession });
 
 // 拦截页面对 Chrome 调试端口的探测（反风控）
 // 只拦截 127.0.0.1:{chromePort} 的请求，不影响其他任何本地服务
@@ -503,34 +506,18 @@ const server = http.createServer(async (req, res) => {
       res.end(JSON.stringify({ clicked: true, x: coord.x, y: coord.y, tag: coord.tag, text: coord.text }));
     }
 
-    // POST /setFiles?target=xxx — 给 file input 设置本地文件（绕过文件对话框）
-    // body: JSON { "selector": "input[type=file]", "files": ["/path/to/file1.png", "/path/to/file2.png"] }
+    // POST /setFiles?target=xxx — 在主文档或该页面的跨域 iframe/OOPIF 中设置文件
+    // body: JSON { "selector": "input[type=file]", "files": ["/path/to/file.pdf"], "frameUrl": "upload.example.com", "frameIndex": 0 }
     else if (pathname === '/setFiles') {
-      const sid = await ensureSession(q.target);
-      const body = JSON.parse(await readBody(req));
-      if (!body.selector || !body.files) {
+      let body;
+      try {
+        body = JSON.parse(await readBody(req));
+      } catch {
         res.statusCode = 400;
-        res.end(JSON.stringify({ error: '需要 selector 和 files 字段' }));
+        res.end(JSON.stringify({ error: 'POST body 必须是 JSON' }));
         return;
       }
-      // 获取 DOM 节点
-      await sendCDP('DOM.enable', {}, sid);
-      const doc = await sendCDP('DOM.getDocument', {}, sid);
-      const node = await sendCDP('DOM.querySelector', {
-        nodeId: doc.result.root.nodeId,
-        selector: body.selector
-      }, sid);
-      if (!node.result?.nodeId) {
-        res.statusCode = 400;
-        res.end(JSON.stringify({ error: '未找到元素: ' + body.selector }));
-        return;
-      }
-      // 设置文件
-      await sendCDP('DOM.setFileInputFiles', {
-        nodeId: node.result.nodeId,
-        files: body.files
-      }, sid);
-      res.end(JSON.stringify({ success: true, files: body.files.length }));
+      res.end(JSON.stringify(await setFilesAcrossFrames(q.target, body)));
     }
 
     // GET /scroll?target=xxx&y=3000 - 滚动
@@ -604,7 +591,7 @@ const server = http.createServer(async (req, res) => {
       }));
     }
   } catch (e) {
-    res.statusCode = 500;
+    res.statusCode = e instanceof SetFilesError ? e.statusCode : 500;
     res.end(JSON.stringify({ error: e.message }));
   }
 });

--- a/scripts/set-files.mjs
+++ b/scripts/set-files.mjs
@@ -1,0 +1,240 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export class SetFilesError extends Error {
+  constructor(statusCode, message) {
+    super(message);
+    this.name = 'SetFilesError';
+    this.statusCode = statusCode;
+  }
+}
+
+export function normalizeSetFilesBody(body, statSync = fs.statSync) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new SetFilesError(400, 'POST body 必须是 JSON 对象');
+  }
+  if (typeof body.selector !== 'string' || !body.selector.trim()) {
+    throw new SetFilesError(400, '需要非空 selector 字段');
+  }
+  if (!Array.isArray(body.files) || body.files.length === 0 ||
+      !body.files.every(file => typeof file === 'string' && file.trim())) {
+    throw new SetFilesError(400, 'files 必须是非空文件路径数组');
+  }
+
+  const files = [...new Set(body.files.map(file => path.resolve(file)))];
+  for (const file of files) {
+    let stat;
+    try {
+      stat = statSync(file);
+    } catch {
+      throw new SetFilesError(400, `文件不存在: ${file}`);
+    }
+    if (!stat.isFile()) {
+      throw new SetFilesError(400, `不是普通文件: ${file}`);
+    }
+  }
+
+  const frameIndex = body.frameIndex == null ? null : Number(body.frameIndex);
+  if (frameIndex != null && (!Number.isInteger(frameIndex) || frameIndex < 0)) {
+    throw new SetFilesError(400, 'frameIndex 必须是非负整数');
+  }
+
+  return {
+    selector: body.selector.trim(),
+    files,
+    frameUrl: typeof body.frameUrl === 'string' ? body.frameUrl.trim() : '',
+    frameIndex,
+  };
+}
+
+function unwrapResult(response, method) {
+  if (response?.error) {
+    throw new Error(`${method} 失败: ${response.error.message || JSON.stringify(response.error)}`);
+  }
+  return response?.result || {};
+}
+
+function isTransientFrameError(error) {
+  return /No target with given id|Session with given id not found|Target closed|detached|not attached/i
+    .test(error?.message || '');
+}
+
+function collectSearchRoots(node, inheritedUrl = '', roots = [], seen = new Set()) {
+  if (!node || seen.has(node.nodeId)) return roots;
+  seen.add(node.nodeId);
+
+  const url = node.documentURL || inheritedUrl;
+  if (node.nodeType === 9 || node.shadowRootType) {
+    roots.push({ nodeId: node.nodeId, url });
+  }
+
+  if (node.contentDocument) collectSearchRoots(node.contentDocument, url, roots, seen);
+  for (const shadowRoot of node.shadowRoots || []) {
+    collectSearchRoots(shadowRoot, url, roots, seen);
+  }
+  for (const child of node.children || []) {
+    collectSearchRoots(child, url, roots, seen);
+  }
+  return roots;
+}
+
+function isTargetDescendantOf(targetInfo, pageTargetId, targetsById) {
+  const seen = new Set([targetInfo.targetId]);
+  let parentId = targetInfo.parentId || targetInfo.parentFrameId;
+  while (parentId && !seen.has(parentId)) {
+    if (parentId === pageTargetId) return true;
+    seen.add(parentId);
+    const parent = targetsById.get(parentId);
+    if (!parent) return false;
+    parentId = parent.parentId || parent.parentFrameId;
+  }
+  return false;
+}
+
+async function findCandidatesInSession({
+  sendCDP,
+  sessionId,
+  selector,
+  frameUrl,
+  targetId,
+  context,
+  defaultUrl,
+  order,
+}) {
+  unwrapResult(await sendCDP('DOM.enable', {}, sessionId), 'DOM.enable');
+  const documentResponse = await sendCDP(
+    'DOM.getDocument',
+    { depth: -1, pierce: true },
+    sessionId,
+  );
+  const root = unwrapResult(documentResponse, 'DOM.getDocument').root;
+  if (!root?.nodeId) return [];
+
+  const candidates = [];
+  for (const searchRoot of collectSearchRoots(root, defaultUrl)) {
+    const url = searchRoot.url || defaultUrl;
+    if (frameUrl && !url.includes(frameUrl)) continue;
+
+    const queryResponse = await sendCDP(
+      'DOM.querySelectorAll',
+      { nodeId: searchRoot.nodeId, selector },
+      sessionId,
+    );
+    if (queryResponse?.error) {
+      const detail = queryResponse.error.message || JSON.stringify(queryResponse.error);
+      if (/selector|query/i.test(detail)) {
+        throw new SetFilesError(400, `无效 selector: ${selector}（${detail}）`);
+      }
+      throw new Error(`DOM.querySelectorAll 失败: ${detail}`);
+    }
+    const nodeIds = (queryResponse?.result || {}).nodeIds || [];
+    for (const nodeId of nodeIds) {
+      candidates.push({
+        targetId,
+        sessionId,
+        nodeId,
+        context,
+        frameUrl: url,
+        order,
+      });
+    }
+  }
+  return candidates;
+}
+
+export function createSetFilesAcrossFrames({ sendCDP, ensureSession }) {
+  return async function setFilesAcrossFrames(pageTargetId, rawBody) {
+    if (typeof pageTargetId !== 'string' || !pageTargetId) {
+      throw new SetFilesError(400, '需要 target 参数');
+    }
+    const body = normalizeSetFilesBody(rawBody);
+    const pageSessionId = await ensureSession(pageTargetId);
+
+    const targetsResponse = await sendCDP('Target.getTargets');
+    const targetInfos = unwrapResult(targetsResponse, 'Target.getTargets').targetInfos || [];
+    const pageInfo = targetInfos.find(info => info.targetId === pageTargetId && info.type === 'page');
+    if (!pageInfo) {
+      throw new SetFilesError(404, `未找到页面 target: ${pageTargetId}`);
+    }
+
+    const candidates = await findCandidatesInSession({
+      sendCDP,
+      sessionId: pageSessionId,
+      selector: body.selector,
+      frameUrl: body.frameUrl,
+      targetId: pageTargetId,
+      context: 'page',
+      defaultUrl: pageInfo.url || '',
+      order: -1,
+    });
+
+    const targetsById = new Map(targetInfos.map(info => [info.targetId, info]));
+    const oopifTargets = targetInfos
+      .filter(info => info.type === 'iframe' && isTargetDescendantOf(info, pageTargetId, targetsById))
+      .sort((a, b) =>
+        (a.url || '').localeCompare(b.url || '') || a.targetId.localeCompare(b.targetId));
+
+    for (const [index, info] of oopifTargets.entries()) {
+      const url = info.url || '';
+      if (body.frameUrl && !url.includes(body.frameUrl)) continue;
+
+      try {
+        const sessionId = await ensureSession(info.targetId);
+        candidates.push(...await findCandidatesInSession({
+          sendCDP,
+          sessionId,
+          selector: body.selector,
+          frameUrl: body.frameUrl,
+          targetId: info.targetId,
+          context: 'iframe',
+          defaultUrl: url,
+          order: index,
+        }));
+      } catch (error) {
+        // OOPIF 可能在枚举后导航或销毁；跳过失效 target，继续检查同一页面的其他候选。
+        if (!isTransientFrameError(error)) throw error;
+      }
+    }
+
+    candidates.sort((a, b) => a.order - b.order);
+    if (candidates.length === 0) {
+      const scope = body.frameUrl
+        ? `URL 包含 ${body.frameUrl} 的页面 frame`
+        : '主文档及其 iframe';
+      throw new SetFilesError(404, `未在${scope}找到元素: ${body.selector}`);
+    }
+
+    let chosen;
+    if (body.frameIndex != null) {
+      chosen = candidates[body.frameIndex];
+      if (!chosen) {
+        throw new SetFilesError(
+          400,
+          `frameIndex ${body.frameIndex} 超出候选范围（共 ${candidates.length} 个）`,
+        );
+      }
+    } else if (candidates.length === 1) {
+      chosen = candidates[0];
+    } else {
+      const summary = candidates.map(({ context, frameUrl: url }) => ({ context, url }));
+      throw new SetFilesError(
+        409,
+        `找到 ${candidates.length} 个匹配文件控件，请提供 frameUrl 或 frameIndex: ${JSON.stringify(summary)}`,
+      );
+    }
+
+    unwrapResult(await sendCDP(
+      'DOM.setFileInputFiles',
+      { nodeId: chosen.nodeId, files: body.files },
+      chosen.sessionId,
+    ), 'DOM.setFileInputFiles');
+
+    return {
+      success: true,
+      files: body.files.length,
+      targetId: chosen.targetId,
+      context: chosen.context,
+      frameUrl: chosen.frameUrl || null,
+    };
+  };
+}

--- a/tests/set-files.integration.test.mjs
+++ b/tests/set-files.integration.test.mjs
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { createSetFilesAcrossFrames } from '../scripts/set-files.mjs';
+
+const CHROME_BIN = process.env.CHROME_BIN;
+
+function listen(server, host) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, host, () => resolve(server.address().port));
+  });
+}
+
+function closeServer(server) {
+  return new Promise(resolve => server.close(resolve));
+}
+
+async function waitForFile(file, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const content = fs.readFileSync(file, 'utf8').trim();
+      if (content) return content;
+    } catch {}
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${file}`);
+}
+
+async function waitFor(predicate, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await predicate();
+    if (value) return value;
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  throw new Error('Timed out waiting for browser state');
+}
+
+function createCDPClient(url) {
+  const ws = new WebSocket(url);
+  const pending = new Map();
+  let commandId = 0;
+
+  const opened = new Promise((resolve, reject) => {
+    ws.addEventListener('open', resolve, { once: true });
+    ws.addEventListener('error', reject, { once: true });
+  });
+  ws.addEventListener('message', event => {
+    const message = JSON.parse(event.data);
+    const entry = pending.get(message.id);
+    if (!entry) return;
+    pending.delete(message.id);
+    entry.resolve(message);
+  });
+
+  return {
+    opened,
+    close: () => ws.close(),
+    send(method, params = {}, sessionId = null) {
+      return new Promise((resolve, reject) => {
+        const id = ++commandId;
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error(`CDP command timed out: ${method}`));
+        }, 10_000);
+        pending.set(id, {
+          resolve: message => {
+            clearTimeout(timer);
+            resolve(message);
+          },
+        });
+        const message = { id, method, params };
+        if (sessionId) message.sessionId = sessionId;
+        ws.send(JSON.stringify(message));
+      });
+    },
+  };
+}
+
+test('uploads through one CDP WebSocket to a real cross-site OOPIF', {
+  skip: !CHROME_BIN && 'Set CHROME_BIN to run the Chrome integration test',
+  timeout: 30_000,
+}, async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'web-access-oopif-'));
+  const uploadFile = path.join(tempDir, 'fixture.txt');
+  fs.writeFileSync(uploadFile, 'fixture');
+
+  const frameServer = http.createServer((request, response) => {
+    response.setHeader('Content-Type', 'text/html; charset=utf-8');
+    response.end('<!doctype html><input id="upload" type="file">');
+  });
+  const framePort = await listen(frameServer, 'localhost');
+  const pageServer = http.createServer((request, response) => {
+    response.setHeader('Content-Type', 'text/html; charset=utf-8');
+    response.end(`<!doctype html><iframe src="http://localhost:${framePort}/frame"></iframe>`);
+  });
+  const pagePort = await listen(pageServer, '127.0.0.1');
+
+  const chrome = spawn(CHROME_BIN, [
+    '--headless=new',
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-gpu',
+    '--site-per-process',
+    '--remote-debugging-port=0',
+    `--user-data-dir=${tempDir}`,
+    'about:blank',
+  ], { stdio: 'ignore' });
+
+  let cdp;
+  try {
+    const activePort = await waitForFile(path.join(tempDir, 'DevToolsActivePort'));
+    const [port, wsPath] = activePort.split(/\r?\n/);
+    cdp = createCDPClient(`ws://127.0.0.1:${port}${wsPath}`);
+    await cdp.opened;
+
+    const sessions = new Map();
+    async function ensureSession(targetId) {
+      if (sessions.has(targetId)) return sessions.get(targetId);
+      const response = await cdp.send('Target.attachToTarget', { targetId, flatten: true });
+      if (response.error) throw new Error(response.error.message);
+      sessions.set(targetId, response.result.sessionId);
+      return response.result.sessionId;
+    }
+
+    const targetResponse = await cdp.send('Target.createTarget', {
+      url: `http://127.0.0.1:${pagePort}/page`,
+    });
+    const pageTargetId = targetResponse.result.targetId;
+    await waitFor(async () => {
+      const response = await cdp.send('Target.getTargets');
+      return response.result?.targetInfos?.some(info =>
+        info.type === 'iframe' && info.url.includes(`localhost:${framePort}`));
+    });
+
+    const setFiles = createSetFilesAcrossFrames({
+      sendCDP: cdp.send.bind(cdp),
+      ensureSession,
+    });
+    const result = await setFiles(pageTargetId, {
+      selector: '#upload',
+      files: [uploadFile],
+      frameUrl: `localhost:${framePort}`,
+    });
+
+    assert.equal(result.context, 'iframe');
+    assert.equal(result.frameUrl.includes(`localhost:${framePort}`), true);
+    const iframeSessionId = await ensureSession(result.targetId);
+    const verify = await cdp.send('Runtime.evaluate', {
+      expression: 'document.querySelector("#upload").files[0]?.name',
+      returnByValue: true,
+    }, iframeSessionId);
+    assert.equal(verify.result.result.value, 'fixture.txt');
+
+    const targetsAfterUpload = await cdp.send('Target.getTargets');
+    assert.equal(
+      targetsAfterUpload.result.targetInfos.some(info => info.targetId === pageTargetId),
+      true,
+    );
+    await cdp.send('Target.closeTarget', { targetId: pageTargetId });
+  } finally {
+    cdp?.close();
+    await Promise.all([closeServer(pageServer), closeServer(frameServer)]);
+    const chromeExited = new Promise(resolve => chrome.once('exit', resolve));
+    if (chrome.exitCode == null) chrome.kill('SIGTERM');
+    await Promise.race([
+      chromeExited,
+      new Promise(resolve => setTimeout(resolve, 3_000)),
+    ]);
+    if (chrome.exitCode == null) {
+      chrome.kill('SIGKILL');
+      await chromeExited;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+});

--- a/tests/set-files.test.mjs
+++ b/tests/set-files.test.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  createSetFilesAcrossFrames,
+  normalizeSetFilesBody,
+  SetFilesError,
+} from '../scripts/set-files.mjs';
+
+function documentNode(nodeId, documentURL) {
+  return { nodeId, nodeType: 9, documentURL, children: [] };
+}
+
+function createMock({ matches = {}, includeSecondFrame = false, queryErrors = {}, staleTargets = [] } = {}) {
+  const calls = [];
+  const targetInfos = [
+    { targetId: 'PAGE', type: 'page', url: 'https://app.example.test' },
+    { targetId: 'FRAME_A', type: 'iframe', url: 'https://upload.example.test/form', parentId: 'PAGE' },
+    { targetId: 'OTHER_PAGE', type: 'page', url: 'https://other.example.test' },
+    { targetId: 'OTHER_FRAME', type: 'iframe', url: 'https://upload.example.test/unrelated', parentId: 'OTHER_PAGE' },
+  ];
+  if (includeSecondFrame) {
+    targetInfos.push({ targetId: 'FRAME_B', type: 'iframe', url: 'https://upload.example.test/second', parentId: 'FRAME_A' });
+  }
+
+  const roots = {
+    SID_PAGE: documentNode(1, 'https://app.example.test'),
+    SID_FRAME_A: documentNode(2, 'https://upload.example.test/form'),
+    SID_FRAME_B: documentNode(3, 'https://upload.example.test/second'),
+    SID_OTHER_FRAME: documentNode(4, 'https://upload.example.test/unrelated'),
+  };
+
+  async function sendCDP(method, params, sessionId) {
+    calls.push({ method, params, sessionId });
+    if (method === 'Target.getTargets') return { result: { targetInfos } };
+    if (method === 'DOM.enable') return { result: {} };
+    if (method === 'DOM.getDocument') return { result: { root: roots[sessionId] } };
+    if (method === 'DOM.querySelectorAll') {
+      const error = queryErrors[`${sessionId}:${params.nodeId}`];
+      if (error) return { error: { message: error } };
+      return { result: { nodeIds: matches[`${sessionId}:${params.nodeId}`] || [] } };
+    }
+    if (method === 'DOM.setFileInputFiles') return { result: {} };
+    throw new Error(`Unexpected method: ${method}`);
+  }
+
+  async function ensureSession(targetId) {
+    if (staleTargets.includes(targetId)) throw new Error('No target with given id found');
+    return {
+      PAGE: 'SID_PAGE',
+      FRAME_A: 'SID_FRAME_A',
+      FRAME_B: 'SID_FRAME_B',
+      OTHER_FRAME: 'SID_OTHER_FRAME',
+    }[targetId];
+  }
+
+  return {
+    calls,
+    setFiles: createSetFilesAcrossFrames({ sendCDP, ensureSession }),
+  };
+}
+
+async function withTempFile(callback) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'web-access-set-files-'));
+  const file = path.join(dir, 'fixture.txt');
+  fs.writeFileSync(file, 'fixture');
+  try {
+    return await callback(file);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('normalizeSetFilesBody resolves, validates, and deduplicates files', async () => {
+  await withTempFile(file => {
+    const body = normalizeSetFilesBody({
+      selector: ' input[type=file] ',
+      files: [file, file],
+      frameUrl: ' upload.example.test ',
+      frameIndex: 0,
+    });
+    assert.equal(body.selector, 'input[type=file]');
+    assert.deepEqual(body.files, [file]);
+    assert.equal(body.frameUrl, 'upload.example.test');
+    assert.equal(body.frameIndex, 0);
+  });
+});
+
+test('normalizeSetFilesBody rejects missing files and invalid frameIndex', () => {
+  assert.throws(
+    () => normalizeSetFilesBody({ selector: 'input', files: ['/missing/file'] }),
+    error => error instanceof SetFilesError && error.statusCode === 400,
+  );
+  assert.throws(
+    () => normalizeSetFilesBody({ selector: 'input', files: ['x'], frameIndex: -1 }, () => ({ isFile: () => true })),
+    error => error instanceof SetFilesError && error.statusCode === 400,
+  );
+});
+
+test('uploads to a single top-level file input', async () => {
+  await withTempFile(async file => {
+    const { calls, setFiles } = createMock({ matches: { 'SID_PAGE:1': [11] } });
+    const result = await setFiles('PAGE', { selector: 'input[type=file]', files: [file] });
+    assert.equal(result.context, 'page');
+    assert.equal(result.targetId, 'PAGE');
+    const upload = calls.find(call => call.method === 'DOM.setFileInputFiles');
+    assert.equal(upload.sessionId, 'SID_PAGE');
+    assert.equal(upload.params.nodeId, 11);
+  });
+});
+
+test('uploads to an OOPIF owned by the requested page', async () => {
+  await withTempFile(async file => {
+    const { calls, setFiles } = createMock({ matches: { 'SID_FRAME_A:2': [21] } });
+    const result = await setFiles('PAGE', {
+      selector: 'input[type=file]',
+      files: [file],
+      frameUrl: 'upload.example.test',
+    });
+    assert.equal(result.context, 'iframe');
+    assert.equal(result.targetId, 'FRAME_A');
+    const upload = calls.find(call => call.method === 'DOM.setFileInputFiles');
+    assert.equal(upload.sessionId, 'SID_FRAME_A');
+  });
+});
+
+test('never scans an iframe outside the requested page target hierarchy', async () => {
+  await withTempFile(async file => {
+    const { calls, setFiles } = createMock({ matches: { 'SID_FRAME_A:2': [21] } });
+    await setFiles('PAGE', {
+      selector: 'input[type=file]',
+      files: [file],
+      frameUrl: 'upload.example.test',
+    });
+    assert.equal(calls.some(call => call.sessionId === 'SID_OTHER_FRAME'), false);
+  });
+});
+
+test('refuses ambiguous matches before changing any input', async () => {
+  await withTempFile(async file => {
+    const { calls, setFiles } = createMock({
+      matches: { 'SID_PAGE:1': [11], 'SID_FRAME_A:2': [21] },
+    });
+    await assert.rejects(
+      setFiles('PAGE', { selector: 'input[type=file]', files: [file] }),
+      error => error instanceof SetFilesError && error.statusCode === 409,
+    );
+    assert.equal(calls.some(call => call.method === 'DOM.setFileInputFiles'), false);
+  });
+});
+
+test('frameIndex selects a deterministic candidate within the requested page', async () => {
+  await withTempFile(async file => {
+    const { calls, setFiles } = createMock({
+      includeSecondFrame: true,
+      matches: { 'SID_FRAME_A:2': [21], 'SID_FRAME_B:3': [31] },
+    });
+    const result = await setFiles('PAGE', {
+      selector: 'input[type=file]',
+      files: [file],
+      frameUrl: 'upload.example.test',
+      frameIndex: 1,
+    });
+    assert.equal(result.targetId, 'FRAME_B');
+    const upload = calls.find(call => call.method === 'DOM.setFileInputFiles');
+    assert.equal(upload.sessionId, 'SID_FRAME_B');
+    assert.equal(upload.params.nodeId, 31);
+  });
+});
+
+test('reports an invalid selector instead of treating it as a missing element', async () => {
+  await withTempFile(async file => {
+    const { setFiles } = createMock({ queryErrors: { 'SID_PAGE:1': 'DOM Error while querying' } });
+    await assert.rejects(
+      setFiles('PAGE', { selector: '[', files: [file] }),
+      error => error instanceof SetFilesError && error.statusCode === 400 && /无效 selector/.test(error.message),
+    );
+  });
+});
+
+test('skips an OOPIF that disappears after target discovery', async () => {
+  await withTempFile(async file => {
+    const { calls, setFiles } = createMock({
+      includeSecondFrame: true,
+      staleTargets: ['FRAME_A'],
+      matches: { 'SID_FRAME_B:3': [31] },
+    });
+    const result = await setFiles('PAGE', {
+      selector: 'input[type=file]',
+      files: [file],
+      frameUrl: 'upload.example.test',
+    });
+    assert.equal(result.targetId, 'FRAME_B');
+    const upload = calls.find(call => call.method === 'DOM.setFileInputFiles');
+    assert.equal(upload.sessionId, 'SID_FRAME_B');
+  });
+});


### PR DESCRIPTION
## Summary

- Extend `POST /setFiles` to locate file inputs in the top-level document, same-process iframe/open shadow roots, and page-owned cross-origin iframe/OOPIF targets.
- Keep existing unambiguous top-level calls backward compatible and reuse the proxy's single browser WebSocket.
- Validate and normalize file paths, support `frameUrl`/`frameIndex` disambiguation, and fail safely when multiple inputs match.
- Scope OOPIF discovery through CDP `TargetInfo.parentId`/`parentFrameId`, so matching frames in unrelated tabs are never scanned.
- Document the single-proxy upload workflow and add unit plus real-Chrome integration coverage.

Related: #156. This PR addresses only the file-upload subset of the broader iframe/OOPIF request.

## Motivation

The existing `/setFiles` implementation only queries the top-level document. File inputs hosted in cross-origin iframe/OOPIF targets cannot be reached from that session, which can push callers toward a second Playwright/Puppeteer/CDP controller. Switching controllers or restarting the proxy can trigger repeated remote-debugging authorization and can lose the active business target or unsaved page state.

This change keeps upload handling inside the long-lived proxy and continues to use `DOM.setFileInputFiles`, avoiding native Open/Save dialogs.

## API

Existing unambiguous calls remain valid:

```json
{"selector":"input[type=file]","files":["/absolute/path/file.pdf"]}
```

Cross-origin iframe example:

```json
{
  "selector":"input[type=file]",
  "files":["/absolute/path/file.pdf"],
  "frameUrl":"upload.example.com"
}
```

If multiple inputs remain, callers can provide `frameIndex`. Without enough disambiguation the endpoint returns HTTP 409 before modifying any input.

This deliberately changes the ambiguous-selector case: a call that matches multiple inputs now fails with HTTP 409 instead of relying on DOM order and selecting the first match.

## Validation

- `node --check scripts/cdp-proxy.mjs`
- `node --check scripts/set-files.mjs`
- `node --test tests/*.test.mjs` — 9 passed, 1 integration test skipped unless `CHROME_BIN` is set
- `CHROME_BIN="/path/to/chrome" node --test tests/set-files.integration.test.mjs` — passed against a real cross-site OOPIF using one browser WebSocket
- `git diff --check` — passed

The integration test verifies that the file name appears in `input.files[0]` inside the OOPIF and that the top-level page target remains alive after upload.

## Notes

- This PR does not add batch actions, site-specific selectors, or Playwright/Puppeteer dependencies.
- It keeps the existing Node.js 22+ baseline and adds no runtime dependencies.
- It does not bypass Chrome's initial remote-debugging authorization; it avoids extra prompts caused by proxy restarts or controller switching.
