### PR TITLE
feat: add CDP drag endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ AI Agent 原本的联网能力（WebSearch、WebFetch）缺少调度策略和浏
 |------|------|
 | 联网工具自动选择 | WebSearch / WebFetch / curl / Jina / CDP，按场景自主判断，可任意组合 |
 | CDP Proxy 浏览器操作 | 直连用户日常浏览器（Chrome / Edge / Chromium 系），天然携带登录态，支持动态页面、交互操作、视频截帧 |
-| 浏览器交互 | `/click`（JS click）、`/clickAt`（CDP 真实点击）、`/drag`（CDP 真实拖拽）、`/setFiles`（文件上传） |
+| 三种点击方式 | `/click`（JS click）、`/clickAt`（CDP 真实鼠标事件）、`/setFiles`（文件上传） |
+| 真实鼠标拖拽 | `/drag`（CDP 真实拖拽） |
 | 本地浏览器书签/历史检索 | `find-url.mjs` 跨 Chrome / Edge 查询公网搜不到的目标（内部系统）或用户访问过的页面，支持关键词/时间窗/访问频度排序 |
 | 并行分治 | 多目标时分发子 Agent 并行执行，共享一个 Proxy，tab 级隔离 |
 | 站点经验积累 | 按域名存储操作经验（URL 模式、平台特征、已知陷阱），跨 session 复用 |
@@ -180,12 +181,6 @@ curl -s "http://localhost:3456/health"                                      # �
 ```
 
 Proxy 会自动追踪通过 `/new` 创建的 tab，闲置 15 分钟后自动关闭，防止 Agent 异常退出时留下孤儿 tab。可通过环境变量 `CDP_TAB_IDLE_TIMEOUT`（单位毫秒）调整超时时间。
-
-拖拽集成测试会启动独立 Proxy 并操作本地测试页；用 `WEB_ACCESS_TEST_BROWSER` 指定已开启远程调试的浏览器：
-
-```bash
-WEB_ACCESS_TEST_BROWSER=chromium node --test tests/drag.test.mjs
-```
 
 ## ⚠️ 使用前提醒
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ AI Agent 原本的联网能力（WebSearch、WebFetch）缺少调度策略和浏
 |------|------|
 | 联网工具自动选择 | WebSearch / WebFetch / curl / Jina / CDP，按场景自主判断，可任意组合 |
 | CDP Proxy 浏览器操作 | 直连用户日常浏览器（Chrome / Edge / Chromium 系），天然携带登录态，支持动态页面、交互操作、视频截帧 |
-| 三种点击方式 | `/click`（JS click）、`/clickAt`（CDP 真实鼠标事件）、`/setFiles`（文件上传） |
+| 浏览器交互 | `/click`（JS click）、`/clickAt`（CDP 真实点击）、`/drag`（CDP 真实拖拽）、`/setFiles`（文件上传） |
 | 本地浏览器书签/历史检索 | `find-url.mjs` 跨 Chrome / Edge 查询公网搜不到的目标（内部系统）或用户访问过的页面，支持关键词/时间窗/访问频度排序 |
 | 并行分治 | 多目标时分发子 Agent 并行执行，共享一个 Proxy，tab 级隔离 |
 | 站点经验积累 | 按域名存储操作经验（URL 模式、平台特征、已知陷阱），跨 session 复用 |
@@ -169,6 +169,8 @@ curl -s -X POST --data-raw 'https://example.com' http://localhost:3456/new  # �
 curl -s -X POST "http://localhost:3456/eval?target=ID" -d 'document.title'  # 执行 JS
 curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'  # JS 点击
 curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d '.upload-btn'  # 真实鼠标点击
+curl -s -X POST "http://localhost:3456/drag?target=ID" \
+  -d '{"source":".handle","deltaX":240,"deltaY":0}'                   # 真实鼠标拖拽
 curl -s -X POST "http://localhost:3456/setFiles?target=ID" \
   -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'        # 文件上传
 curl -s "http://localhost:3456/screenshot?target=ID&file=/tmp/shot.png"     # 截图
@@ -178,6 +180,12 @@ curl -s "http://localhost:3456/health"                                      # �
 ```
 
 Proxy 会自动追踪通过 `/new` 创建的 tab，闲置 15 分钟后自动关闭，防止 Agent 异常退出时留下孤儿 tab。可通过环境变量 `CDP_TAB_IDLE_TIMEOUT`（单位毫秒）调整超时时间。
+
+拖拽集成测试会启动独立 Proxy 并操作本地测试页；用 `WEB_ACCESS_TEST_BROWSER` 指定已开启远程调试的浏览器：
+
+```bash
+WEB_ACCESS_TEST_BROWSER=chromium node --test tests/drag.test.mjs
+```
 
 ## ⚠️ 使用前提醒
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -147,6 +147,10 @@ curl -s -X POST "http://localhost:3456/click?target=ID" -d 'button.submit'
 # 真实鼠标点击 — CDP Input.dispatchMouseEvent，算用户手势，能触发文件对话框
 curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
 
+# 真实鼠标拖拽 — 支持拖到目标元素或按相对位移拖动
+curl -s -X POST "http://localhost:3456/drag?target=ID" \
+  -d '{"source":".handle","deltaX":240,"deltaY":0}'
+
 # 文件上传 — 直接设置 file input 的本地文件路径，绕过文件对话框
 curl -s -X POST "http://localhost:3456/setFiles?target=ID" -d '{"selector":"input[type=file]","files":["/path/to/file.png"]}'
 

--- a/references/cdp-api.md
+++ b/references/cdp-api.md
@@ -75,6 +75,42 @@ CDP 浏览器级真实鼠标点击（`Input.dispatchMouseEvent`），POST body �
 curl -s -X POST "http://localhost:3456/clickAt?target=ID" -d 'button.upload'
 ```
 
+### POST /drag?target=ID
+CDP 浏览器级真实鼠标拖拽。`source` 是起点元素的 CSS 选择器；终点可用 `target` 元素选择器，或用 `deltaX` / `deltaY` 指定相对于起点中心的位移。
+
+拖到目标元素中心：
+
+```bash
+curl -s -X POST "http://localhost:3456/drag?target=ID" \
+  -d '{"source":".card","target":".drop-zone","steps":12,"durationMs":300}'
+```
+
+按相对位移拖动：
+
+```bash
+curl -s -X POST "http://localhost:3456/drag?target=ID" \
+  -d '{"source":".slider-handle","deltaX":240,"deltaY":0,"steps":12,"durationMs":300}'
+```
+
+- `target` 与 `deltaX` / `deltaY` 不能同时使用。
+- `steps` 默认 `12`，范围为 `1` 到 `100`。
+- `durationMs` 默认 `300`，范围为 `0` 到 `10000`。
+- 拖拽前会通过 `Page.bringToFront` 激活目标标签页，以避免 Chromium 对后台连续输入事件进行节流；这会改变浏览器当前标签页，接口不会自动恢复先前标签页。
+- 源元素和目标元素必须有非零尺寸、中心点未被遮挡，并位于当前页面视口中；相对位移的终点也必须位于视口中。
+- `/drag` 与 `/clickAt` 的真实鼠标事件会串行执行，避免并发请求互相释放按键。
+
+成功时返回起点、终点、步数和持续时间：
+
+```json
+{
+  "dragged": true,
+  "from": { "x": 120, "y": 200 },
+  "to": { "x": 360, "y": 200 },
+  "steps": 12,
+  "durationMs": 300
+}
+```
+
 ### POST /setFiles?target=ID
 给 file input 设置本地文件路径（`DOM.setFileInputFiles`），完全绕过文件对话框。POST body 为 JSON。
 ```bash

--- a/scripts/cdp-proxy.mjs
+++ b/scripts/cdp-proxy.mjs
@@ -319,6 +319,25 @@ async function readBody(req) {
   return body;
 }
 
+// 浏览器级鼠标输入共享同一个真实指针状态，必须串行执行，避免请求之间互相释放按键。
+let inputQueue = Promise.resolve();
+async function withInputLock(action) {
+  let releaseLock;
+  const previous = inputQueue;
+  inputQueue = new Promise(resolve => { releaseLock = resolve; });
+  await previous;
+  try {
+    return await action();
+  } finally {
+    releaseLock();
+  }
+}
+
+async function dispatchMouseEvent(params, sessionId) {
+  const response = await sendCDP('Input.dispatchMouseEvent', params, sessionId);
+  if (response.error) throw new Error(response.error.message || JSON.stringify(response.error));
+}
+
 // --- HTTP API ---
 const server = http.createServer(async (req, res) => {
   const parsed = new URL(req.url, `http://localhost:${PORT}`);
@@ -504,13 +523,247 @@ const server = http.createServer(async (req, res) => {
         res.end(JSON.stringify(coord || coordResp.result));
         return;
       }
-      await sendCDP('Input.dispatchMouseEvent', {
-        type: 'mousePressed', x: coord.x, y: coord.y, button: 'left', clickCount: 1
-      }, sid);
-      await sendCDP('Input.dispatchMouseEvent', {
-        type: 'mouseReleased', x: coord.x, y: coord.y, button: 'left', clickCount: 1
-      }, sid);
+      await withInputLock(async () => {
+        let releaseRequired = false;
+        let primaryError = null;
+        try {
+          releaseRequired = true;
+          await dispatchMouseEvent({
+            type: 'mousePressed', x: coord.x, y: coord.y, button: 'left', buttons: 1, clickCount: 1
+          }, sid);
+        } catch (error) {
+          primaryError = error;
+        } finally {
+          if (releaseRequired) {
+            try {
+              await dispatchMouseEvent({
+                type: 'mouseReleased', x: coord.x, y: coord.y, button: 'left', buttons: 0, clickCount: 1
+              }, sid);
+            } catch (releaseError) {
+              if (!primaryError) primaryError = releaseError;
+            }
+          }
+        }
+        if (primaryError) throw primaryError;
+      });
       res.end(JSON.stringify({ clicked: true, x: coord.x, y: coord.y, tag: coord.tag, text: coord.text }));
+    }
+
+    // POST /drag?target=xxx — CDP 浏览器级真实鼠标拖拽
+    // body: JSON { source, target? } 或 { source, deltaX?, deltaY? }，另支持 steps、durationMs
+    else if (pathname === '/drag') {
+      let body;
+      try {
+        body = JSON.parse(await readBody(req));
+      } catch {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'POST body 必须是合法 JSON' }));
+        return;
+      }
+      if (!body || typeof body !== 'object' || Array.isArray(body)) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'POST body 必须是 JSON 对象' }));
+        return;
+      }
+      if (typeof body.source !== 'string' || !body.source.trim()) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: '需要 source CSS 选择器' }));
+        return;
+      }
+      const hasTargetField = Object.hasOwn(body, 'target');
+      const hasDeltaXField = Object.hasOwn(body, 'deltaX');
+      const hasDeltaYField = Object.hasOwn(body, 'deltaY');
+      if (hasTargetField && (typeof body.target !== 'string' || !body.target.trim())) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'target 必须是非空字符串' }));
+        return;
+      }
+      if (hasDeltaXField && !Number.isFinite(body.deltaX)) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'deltaX 必须是数字' }));
+        return;
+      }
+      if (hasDeltaYField && !Number.isFinite(body.deltaY)) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'deltaY 必须是数字' }));
+        return;
+      }
+      const hasTarget = hasTargetField;
+      const hasDelta = hasDeltaXField || hasDeltaYField;
+      if (!hasTarget && !hasDelta) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: '需要 target，或 deltaX/deltaY' }));
+        return;
+      }
+      if (hasTarget && hasDelta) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'target 与 deltaX/deltaY 不能同时使用' }));
+        return;
+      }
+      const steps = body.steps === undefined ? 12 : body.steps;
+      const durationMs = body.durationMs === undefined ? 300 : body.durationMs;
+      if (!Number.isInteger(steps) || steps < 1 || steps > 100) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'steps 必须是 1 到 100 之间的整数' }));
+        return;
+      }
+      if (!Number.isFinite(durationMs) || durationMs < 0 || durationMs > 10000) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'durationMs 必须是 0 到 10000 之间的数字' }));
+        return;
+      }
+      if (!q.target) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: '需要 target tab ID' }));
+        return;
+      }
+
+      const targetsResponse = await sendCDP('Target.getTargets');
+      if (targetsResponse.error) {
+        throw new Error(targetsResponse.error.message || JSON.stringify(targetsResponse.error));
+      }
+      const targetExists = targetsResponse.result?.targetInfos?.some(target => target.targetId === q.target);
+      if (!targetExists) {
+        res.statusCode = 404;
+        res.end(JSON.stringify({ error: '未找到 target tab ID: ' + q.target }));
+        return;
+      }
+
+      const sid = await ensureSession(q.target);
+      let position;
+      let positionError;
+
+      await withInputLock(async () => {
+        const frontResponse = await sendCDP('Page.bringToFront', {}, sid);
+        if (frontResponse.error) throw new Error(frontResponse.error.message || JSON.stringify(frontResponse.error));
+
+        const sourceJson = JSON.stringify(body.source);
+        const targetJson = hasTarget ? JSON.stringify(body.target) : 'null';
+        const positionJs = `(() => {
+          try {
+            const source = document.querySelector(${sourceJson});
+            if (!source) return { error: '未找到元素: ' + ${sourceJson} };
+            source.scrollIntoView({ block: 'center', inline: 'center' });
+            const rect = source.getBoundingClientRect();
+            if (rect.width <= 0 || rect.height <= 0) return { error: '源元素尺寸必须大于 0' };
+            const startX = rect.x + rect.width / 2;
+            const startY = rect.y + rect.height / 2;
+            if (![startX, startY].every(Number.isFinite)) return { error: '源元素坐标无效' };
+            if (startX < 0 || startX >= innerWidth || startY < 0 || startY >= innerHeight) {
+              return { error: '源元素中心不在当前视口中' };
+            }
+            const hitElement = document.elementFromPoint(startX, startY);
+            if (!hitElement || (hitElement !== source && !source.contains(hitElement))) {
+              return { error: '源元素中心被其他元素遮挡' };
+            }
+            const targetSelector = ${targetJson};
+            let endX;
+            let endY;
+            let targetTag = null;
+            if (targetSelector) {
+              const target = document.querySelector(targetSelector);
+              if (!target) return { error: '未找到元素: ' + targetSelector };
+              const targetRect = target.getBoundingClientRect();
+              if (targetRect.width <= 0 || targetRect.height <= 0) return { error: '目标元素尺寸必须大于 0' };
+              endX = targetRect.x + targetRect.width / 2;
+              endY = targetRect.y + targetRect.height / 2;
+              if (![endX, endY].every(Number.isFinite)) return { error: '目标元素坐标无效' };
+              if (endX < 0 || endX >= innerWidth || endY < 0 || endY >= innerHeight) {
+                return { error: '目标元素中心不在当前视口中' };
+              }
+              const targetHitElement = document.elementFromPoint(endX, endY);
+              if (!targetHitElement || (targetHitElement !== target && !target.contains(targetHitElement))) {
+                return { error: '目标元素中心被其他元素遮挡' };
+              }
+              targetTag = target.tagName;
+            } else {
+              endX = startX + ${Number.isFinite(body.deltaX) ? body.deltaX : 0};
+              endY = startY + ${Number.isFinite(body.deltaY) ? body.deltaY : 0};
+              if (![endX, endY].every(Number.isFinite)) return { error: '拖拽终点坐标无效' };
+              if (endX < 0 || endX >= innerWidth || endY < 0 || endY >= innerHeight) {
+                return { error: '拖拽终点不在当前视口中' };
+              }
+            }
+            return {
+              startX,
+              startY,
+              endX,
+              endY,
+              tag: source.tagName,
+              targetTag,
+              hitTag: hitElement?.tagName || null,
+              hitId: hitElement?.id || null,
+            };
+          } catch (error) {
+            return { error: error.message };
+          }
+        })()`;
+        const positionResp = await sendCDP('Runtime.evaluate', {
+          expression: positionJs,
+          returnByValue: true,
+          awaitPromise: true,
+        }, sid);
+        position = positionResp.result?.result?.value;
+        if (!position || position.error) {
+          positionError = position || positionResp.result || { error: '无法获取元素坐标' };
+          return;
+        }
+
+        let currentX = position.startX;
+        let currentY = position.startY;
+        let releaseRequired = false;
+        let primaryError = null;
+        try {
+          // scrollIntoView 可能异步产生一次无按键的 mousemove；先等它落稳，避免混入拖动阶段。
+          await new Promise(resolve => setTimeout(resolve, 100));
+          await dispatchMouseEvent({
+            type: 'mouseMoved', x: currentX, y: currentY, button: 'none', buttons: 0
+          }, sid);
+          await new Promise(resolve => setTimeout(resolve, 50));
+          releaseRequired = true;
+          await dispatchMouseEvent({
+            type: 'mousePressed', x: currentX, y: currentY, button: 'left', buttons: 1, clickCount: 1
+          }, sid);
+          const delayMs = durationMs / steps;
+          for (let step = 1; step <= steps; step++) {
+            currentX = position.startX + (position.endX - position.startX) * step / steps;
+            currentY = position.startY + (position.endY - position.startY) * step / steps;
+            await dispatchMouseEvent({
+              type: 'mouseMoved', x: currentX, y: currentY, button: 'left', buttons: 1
+            }, sid);
+            if (delayMs > 0) await new Promise(resolve => setTimeout(resolve, delayMs));
+          }
+        } catch (error) {
+          primaryError = error;
+        } finally {
+          if (releaseRequired) {
+            try {
+              await dispatchMouseEvent({
+                type: 'mouseReleased', x: currentX, y: currentY, button: 'left', buttons: 0, clickCount: 1
+              }, sid);
+            } catch (releaseError) {
+              if (!primaryError) primaryError = releaseError;
+            }
+          }
+        }
+        if (primaryError) throw primaryError;
+      });
+
+      if (positionError) {
+        res.statusCode = 400;
+        res.end(JSON.stringify(positionError));
+        return;
+      }
+      res.end(JSON.stringify({
+        dragged: true,
+        from: { x: position.startX, y: position.startY },
+        to: { x: position.endX, y: position.endY },
+        steps,
+        durationMs,
+        tag: position.tag,
+        targetTag: position.targetTag,
+        hit: { tag: position.hitTag, id: position.hitId },
+      }));
     }
 
     // POST /setFiles?target=xxx — 给 file input 设置本地文件（绕过文件对话框）
@@ -608,6 +861,7 @@ const server = http.createServer(async (req, res) => {
           '/info?target=': 'GET - 页面标题/URL/状态',
           '/eval?target=': 'POST body=JS表达式 - 执行 JS',
           '/click?target=': 'POST body=CSS选择器 - 点击元素',
+          '/drag?target=': 'POST body=JSON - 拖拽元素',
           '/scroll?target=&y=&direction=': 'GET - 滚动页面',
           '/screenshot?target=&file=': 'GET - 截图',
         },
@@ -652,7 +906,8 @@ async function main() {
   }
 
   server.listen(PORT, '127.0.0.1', () => {
-    console.log(`[CDP Proxy] 运行在 http://localhost:${PORT}`);
+    const listeningPort = server.address().port;
+    console.log(`[CDP Proxy] 运行在 http://localhost:${listeningPort}`);
     // 启动时尝试连接 Chrome（非阻塞）
     connect().catch(e => console.error('[CDP Proxy] 初始连接失败:', e.message, '（将在首次请求时重试）'));
   });

--- a/tests/drag.test.mjs
+++ b/tests/drag.test.mjs
@@ -1,0 +1,330 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function waitForProxy(child, logs) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (child.exitCode !== null) {
+      throw new Error(`CDP Proxy exited early (${child.exitCode}):\n${logs.join('')}`);
+    }
+    const portMatch = logs.join('').match(/\[CDP Proxy\] 运行在 http:\/\/localhost:(\d+)/);
+    if (portMatch) {
+      const baseUrl = `http://127.0.0.1:${portMatch[1]}`;
+      try {
+        const response = await fetch(`${baseUrl}/health`);
+        if (response.ok) return baseUrl;
+      } catch {
+        // The proxy may still be starting.
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`CDP Proxy did not become ready:\n${logs.join('')}`);
+}
+
+async function post(baseUrl, pathname, body) {
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+test('POST /drag moves a page element through real mouse events', async () => {
+  const fixtureServer = http.createServer((request, response) => {
+    response.setHeader('Content-Type', 'text/html; charset=utf-8');
+    response.end(`<!doctype html>
+      <style>
+        #track { position: relative; width: 400px; height: 40px; margin: 100px; background: #ddd; }
+        #track-two { position: relative; width: 400px; height: 40px; margin: 100px; background: #ddd; }
+        #handle { position: absolute; left: 0; width: 40px; height: 40px; background: #1677ff; }
+        #handle-two { position: absolute; left: 0; width: 40px; height: 40px; background: #722ed1; }
+        #target { position: absolute; left: 300px; width: 40px; height: 40px; box-sizing: border-box; border: 3px solid #52c41a; }
+        #zero-size { position: absolute; width: 0; height: 0; }
+      </style>
+      <div id="track"><div id="target"></div><div id="handle"></div><div id="zero-size"></div></div>
+      <div id="track-two"><div id="handle-two"></div></div>
+      <output id="status">idle</output>
+      <button id="click-target">click target</button>
+      <script>
+        window.clickCount = 0;
+        window.dragFixture = {
+          ready: false, error: null, downs: 0, moves: 0, ups: 0,
+          validButtonMoves: 0, invalidButtons: 0, inputOrder: []
+        };
+        try {
+          const handleElement = document.querySelector('#handle');
+          const statusOutput = document.querySelector('#status');
+          let dragging = false;
+          let pointerStart = 0;
+          let handleStart = 0;
+          handleElement.addEventListener('mousedown', (event) => {
+            window.dragFixture.downs++;
+            dragging = true;
+            pointerStart = event.clientX;
+            handleStart = Number.parseFloat(handleElement.style.left) || 0;
+          });
+          document.addEventListener('mousemove', (event) => {
+            window.dragFixture.moves++;
+            if (!dragging) return;
+            if (event.buttons !== 1) {
+              window.dragFixture.invalidButtons++;
+              return;
+            }
+            window.dragFixture.validButtonMoves++;
+            const next = Math.max(0, Math.min(360, handleStart + event.clientX - pointerStart));
+            handleElement.style.left = next + 'px';
+          });
+          document.addEventListener('mouseup', () => {
+            window.dragFixture.ups++;
+            if (!dragging) return;
+            dragging = false;
+            statusOutput.value = Number.parseFloat(handleElement.style.left) >= 200 ? 'dragged' : 'short';
+          });
+          document.addEventListener('mousedown', (event) => {
+            if (event.target.matches('#handle, #handle-two')) {
+              window.dragFixture.inputOrder.push('down:' + event.target.id);
+            }
+          });
+          document.addEventListener('mouseup', () => window.dragFixture.inputOrder.push('up'));
+          document.querySelector('#click-target').addEventListener('click', () => window.clickCount++);
+          window.dragFixture.ready = true;
+        } catch (error) {
+          window.dragFixture.error = error.message;
+        }
+      </script>`);
+  });
+
+  const fixturePort = await listen(fixtureServer);
+
+  const logs = [];
+  const proxyArgs = ['scripts/cdp-proxy.mjs'];
+  if (process.env.WEB_ACCESS_TEST_BROWSER) {
+    proxyArgs.push('--browser', process.env.WEB_ACCESS_TEST_BROWSER);
+  }
+  const proxy = spawn(process.execPath, proxyArgs, {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      CDP_PROXY_PORT: '0',
+      CDP_TAB_IDLE_TIMEOUT: '60000',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  proxy.stdout.on('data', (chunk) => {
+    logs.push(chunk.toString());
+    if (process.env.WEB_ACCESS_TEST_DEBUG) process.stderr.write(chunk);
+  });
+  proxy.stderr.on('data', (chunk) => {
+    logs.push(chunk.toString());
+    if (process.env.WEB_ACCESS_TEST_DEBUG) process.stderr.write(chunk);
+  });
+
+  try {
+    const baseUrl = await waitForProxy(proxy, logs);
+    const created = await post(baseUrl, '/new', `http://127.0.0.1:${fixturePort}`);
+    assert.equal(created.status, 200, JSON.stringify(created.body));
+
+    const initial = await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      `({
+        ready: document.readyState,
+        fixtureReady: window.dragFixture?.ready,
+        fixtureError: window.dragFixture?.error,
+      })`,
+    );
+    assert.deepEqual(initial.body.value, { ready: 'complete', fixtureReady: true, fixtureError: null });
+
+    const dragged = await post(baseUrl, `/drag?target=${created.body.targetId}`, {
+      source: '#handle',
+      deltaX: 240,
+      deltaY: 0,
+      steps: 12,
+      durationMs: 120,
+    });
+    assert.equal(dragged.status, 200, JSON.stringify(dragged.body));
+    assert.deepEqual(dragged.body.hit, { tag: 'DIV', id: 'handle' });
+
+    const result = await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      `({
+        status: document.querySelector('#status').value,
+        left: document.querySelector('#handle').style.left,
+        downs: window.dragFixture.downs,
+        moves: window.dragFixture.moves,
+        ups: window.dragFixture.ups,
+        validButtonMoves: window.dragFixture.validButtonMoves,
+        invalidButtons: window.dragFixture.invalidButtons,
+      })`,
+    );
+    assert.equal(result.body.value.status, 'dragged');
+    assert.equal(result.body.value.left, '240px');
+    assert.equal(result.body.value.downs, 1);
+    assert.ok(result.body.value.moves >= 13, JSON.stringify(result.body.value));
+    assert.equal(result.body.value.ups, 1);
+    assert.ok(result.body.value.validButtonMoves >= 12, JSON.stringify(result.body.value));
+
+    const clicked = await post(baseUrl, `/clickAt?target=${created.body.targetId}`, '#click-target');
+    assert.equal(clicked.status, 200, JSON.stringify(clicked.body));
+    const clickCount = await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      'window.clickCount',
+    );
+    assert.equal(clickCount.body.value, 1);
+
+    await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      `(() => {
+        document.querySelector('#handle').style.left = '0px';
+        document.querySelector('#status').value = 'idle';
+        Object.assign(window.dragFixture, {
+          downs: 0, moves: 0, ups: 0, validButtonMoves: 0, invalidButtons: 0
+        });
+        return true;
+      })()`,
+    );
+    const draggedToTarget = await post(baseUrl, `/drag?target=${created.body.targetId}`, {
+      source: '#handle',
+      target: '#target',
+      steps: 10,
+      durationMs: 100,
+    });
+    assert.equal(draggedToTarget.status, 200, JSON.stringify(draggedToTarget.body));
+
+    const targetResult = await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      `({
+        status: document.querySelector('#status').value,
+        left: document.querySelector('#handle').style.left,
+        downs: window.dragFixture.downs,
+        moves: window.dragFixture.moves,
+        ups: window.dragFixture.ups,
+        validButtonMoves: window.dragFixture.validButtonMoves,
+        invalidButtons: window.dragFixture.invalidButtons,
+      })`,
+    );
+    assert.equal(targetResult.body.value.status, 'dragged');
+    assert.equal(targetResult.body.value.left, '300px');
+    assert.equal(targetResult.body.value.downs, 1);
+    assert.ok(targetResult.body.value.moves >= 11, JSON.stringify(targetResult.body.value));
+    assert.equal(targetResult.body.value.ups, 1);
+    assert.ok(targetResult.body.value.validButtonMoves >= 10, JSON.stringify(targetResult.body.value));
+
+    await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      `(() => {
+        document.querySelector('#handle').style.left = '0px';
+        window.dragFixture.inputOrder = [];
+        return true;
+      })()`,
+    );
+    const concurrentDrags = await Promise.all([
+      post(baseUrl, `/drag?target=${created.body.targetId}`, {
+        source: '#handle', deltaX: 100, steps: 20, durationMs: 200,
+      }),
+      post(baseUrl, `/drag?target=${created.body.targetId}`, {
+        source: '#handle-two', deltaX: 100, steps: 20, durationMs: 200,
+      }),
+    ]);
+    assert.ok(concurrentDrags.every(({ status }) => status === 200), JSON.stringify(concurrentDrags));
+    const inputOrder = await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      'window.dragFixture.inputOrder',
+    );
+    assert.equal(inputOrder.body.value.length, 4, JSON.stringify(inputOrder.body.value));
+    assert.match(inputOrder.body.value[0], /^down:/);
+    assert.equal(inputOrder.body.value[1], 'up');
+    assert.match(inputOrder.body.value[2], /^down:/);
+    assert.equal(inputOrder.body.value[3], 'up');
+
+    const invalidRequests = [
+      ['{', /合法 JSON/],
+      [null, /JSON 对象/],
+      [[], /JSON 对象/],
+      [{ deltaX: 10 }, /source/],
+      [{ source: '#handle' }, /target.*deltaX\/deltaY/],
+      [{ source: '#handle', target: 123, deltaX: 20 }, /target.*字符串/],
+      [{ source: '#handle', target: '#target', deltaX: '20' }, /deltaX.*数字/],
+      [{ source: '#handle', target: '#target', deltaX: 10 }, /不能同时使用/],
+      [{ source: '#missing', deltaX: 10 }, /未找到元素/],
+      [{ source: '#handle', target: '#missing' }, /未找到元素/],
+    ];
+    for (const [body, expectedError] of invalidRequests) {
+      const invalid = await post(baseUrl, `/drag?target=${created.body.targetId}`, body);
+      assert.equal(invalid.status, 400, JSON.stringify(invalid.body));
+      assert.match(invalid.body.error, expectedError);
+    }
+
+    const zeroSize = await post(baseUrl, `/drag?target=${created.body.targetId}`, {
+      source: '#zero-size',
+      deltaX: 10,
+    });
+    assert.equal(zeroSize.status, 400, JSON.stringify(zeroSize.body));
+    assert.match(zeroSize.body.error, /尺寸/);
+
+    await post(
+      baseUrl,
+      `/eval?target=${created.body.targetId}`,
+      `(() => {
+        document.querySelector('#handle').style.left = '0px';
+        const overlay = document.createElement('div');
+        overlay.id = 'overlay';
+        Object.assign(overlay.style, {
+          position: 'absolute', left: '0', top: '0', width: '40px', height: '40px', zIndex: '10'
+        });
+        document.querySelector('#track').append(overlay);
+        return true;
+      })()`,
+    );
+    const coveredSource = await post(baseUrl, `/drag?target=${created.body.targetId}`, {
+      source: '#handle',
+      deltaX: 10,
+    });
+    assert.equal(coveredSource.status, 400, JSON.stringify(coveredSource.body));
+    assert.match(coveredSource.body.error, /遮挡/);
+
+    const missingTab = await post(baseUrl, '/drag', { source: '#handle', deltaX: 10 });
+    assert.equal(missingTab.status, 400, JSON.stringify(missingTab.body));
+    assert.match(missingTab.body.error, /target tab ID/);
+
+    const unknownTab = await post(baseUrl, '/drag?target=does-not-exist', {
+      source: '#handle', deltaX: 10,
+    });
+    assert.equal(unknownTab.status, 404, JSON.stringify(unknownTab.body));
+    assert.match(unknownTab.body.error, /tab/);
+  } finally {
+    proxy.kill('SIGTERM');
+    const exited = await Promise.race([
+      new Promise((resolve) => proxy.once('exit', resolve)),
+      new Promise((resolve) => setTimeout(() => resolve(false), 2000)),
+    ]);
+    if (exited === false && proxy.exitCode === null) {
+      proxy.kill('SIGKILL');
+      await new Promise((resolve) => proxy.once('exit', resolve));
+    }
+    await close(fixtureServer);
+  }
+});


### PR DESCRIPTION
## Summary

- add a `POST /drag?target=ID` endpoint backed by `Input.dispatchMouseEvent`
- support dragging from a CSS selector to another selector or by relative `deltaX` / `deltaY`
- serialize real mouse input shared by `/drag` and `/clickAt`, preserve the primary error, and attempt mouse release after failures
- validate request shape, tab existence, element geometry, viewport bounds, and center-point occlusion
- document tab activation side effects and add usage examples

## Tests

- `node --check scripts/cdp-proxy.mjs`
- `node --check tests/drag.test.mjs`
- `git diff --check upstream/main...HEAD`
- `WEB_ACCESS_TEST_BROWSER=chromium node --test --test-reporter=spec tests/drag.test.mjs` using an isolated Chrome for Testing profile

The integration test exercises both destination modes through the public HTTP API, verifies the left-button bitmask during movement, checks `/clickAt` compatibility and concurrent input serialization, and covers malformed requests, missing tabs/elements, zero-size elements, and occluded sources.

## Real-world validation

The endpoint was also exercised on production pages through the public Proxy API:

- JD, Suning, and Amap login sliders: real handles and progress tracks moved with trusted mouse events; no verification request was submitted.
- Amap and Baidu Maps: dragging the map canvas changed the map center coordinates.
- Bilibili: dragging the actual player progress control changed `video.currentTime` from about `79s` to `544s` and emitted `seeking`/`seeked`.
- Zhihu and CSDN login pages did not expose a draggable challenge before the SMS flow, so no SMS or login request was sent.

These checks validate observable page state changes, rather than relying only on the endpoint's `dragged: true` response.